### PR TITLE
Fixes Blockly.Toolbox.TreeNode implementation

### DIFF
--- a/core/ui/block_space/toolbox.js
+++ b/core/ui/block_space/toolbox.js
@@ -354,11 +354,11 @@ goog.inherits(Blockly.Toolbox.TreeNode, goog.ui.tree.TreeNode);
 
 /**
  * Do not show the +/- icon.
- * @return {string} The source for the icon.
+ * @return {goog.html.SafeHtml} The source for the icon.
  * @override
  */
-Blockly.Toolbox.TreeNode.prototype.getExpandIconHtml = function() {
-  return '<span></span>';
+Blockly.Toolbox.TreeNode.prototype.getExpandIconSafeHtml = function() {
+  return goog.html.SafeHtml.create('span');
 };
 
 /**


### PR DESCRIPTION
Blocklyh.Toolbox.TreeNode is extending the native [goog.ui.tree.TreeNode](https://github.com/google/closure-library/blob/master/closure/goog/ui/tree/treenode.js),
in part to override the functionality of the "expand" element to make it
simply an empty span. Unfortunately, the [implementation of the google
element](https://github.com/google/closure-library/blob/master/closure/goog/ui/tree/basenode.js#L927) updated with the latest version of closure library, and the
Blockly implementation was not updated to match. It now is.

Note that the following grep indiciates that two other elements also extend native closure elements: 

```bash
$ git grep "goog.inherits(Blockly[^,]*, goog.[^)]*)"
ui/block_space/toolbox.js:goog.inherits(Blockly.Toolbox.TreeControl, goog.ui.tree.TreeControl);
ui/block_space/toolbox.js:goog.inherits(Blockly.Toolbox.TreeNode, goog.ui.tree.TreeNode);
ui/closure_tools/custom_css_class_menu_renderer.js:goog.inherits(Blockly.CustomCssClassMenuRenderer, goog.ui.MenuRenderer);
```

However, inspection of those elements indicates that none of their bases were similarly changed.

This PR fixes the regression which prompted https://github.com/code-dot-org/code-dot-org/pull/10978