### PR TITLE
Fix extra whitespace in webkit

### DIFF
--- a/core/ui/block_space/block_space_editor.js
+++ b/core/ui/block_space/block_space_editor.js
@@ -530,6 +530,7 @@ Blockly.BlockSpaceEditor.prototype.detectBrokenControlPoints = function() {
 
      NOTE:
      chromium fixed this bug for path elements in commit 8f4c8e;
+     (https://chromium.googlesource.com/chromium/src.git/+/8f4c8e6d2f1260d68f387b37f078457e4153bbb4)
      unfortunately, the bug still presents itself when getBBox is called
      on containers that CONTAIN such a path element, which is our actual
      use case. Thus, we draw the shape within a container and check the

--- a/core/ui/block_space/block_space_editor.js
+++ b/core/ui/block_space/block_space_editor.js
@@ -527,27 +527,35 @@ Blockly.BlockSpaceEditor.prototype.detectBrokenControlPoints = function() {
      shape that is 50px high, and has a control point that sticks up by 5px.
      If the getBBox function returns a height of 55px instead of 50px, then
      this browser has broken control points.
+
+     NOTE:
+     chromium fixed this bug for path elements in commit 8f4c8e;
+     unfortunately, the bug still presents itself when getBBox is called
+     on containers that CONTAIN such a path element, which is our actual
+     use case. Thus, we draw the shape within a container and check the
+     size of the container.
      */
-    var path = Blockly.createSvgElement('path',
-      {'d': 'm 0,0 c 0,-5 0,-5 0,0 H 50 V 50 z'}, this.svg_);
+    var container = Blockly.createSvgElement('g', {}, this.svg_);
+    Blockly.createSvgElement('path',
+      {'d': 'm 0,0 c 0,-5 0,-5 0,0 H 50 V 50 z'}, container);
     if (Blockly.isMsie() || Blockly.isTrident()) {
-      path.style.display = "inline";
+      container.style.display = "inline";
       /* reqd for IE */
-      path.bBox_ = {
-        x: path.getBBox().x,
-        y: path.getBBox().y,
-        width: path.scrollWidth,
-        height: path.scrollHeight
+      container.bBox_ = {
+        x: container.getBBox().x,
+        y: container.getBBox().y,
+        width: container.scrollWidth,
+        height: container.scrollHeight
       };
     }
     else {
-      path.bBox_ = path.getBBox();
+      container.bBox_ = container.getBBox();
     }
-    if (path.bBox_.height > 50) {
+    if (container.bBox_.height > 50) {
       // Chrome (v28) and Opera (v15) report 55, Safari (v6.0.5) reports 53.75.
       Blockly.BROKEN_CONTROL_POINTS = true;
     }
-    this.svg_.removeChild(path);
+    this.svg_.removeChild(container);
   }
 };
 


### PR DESCRIPTION
A little backstory: webkit browsers have a [long-existing bug](https://bugs.chromium.org/p/chromium/issues/detail?id=230599) where
shapes with control points take those points into account when
calculating the BBox. We had some workarounds in place to detect and
handle this bug, but Chrome [recently fixed this
issue](https://chromium.googlesource.com/chromium/src.git/+/8f4c8e6d2f1260d68f387b37f078457e4153bbb4) _only for paths_. This means that a container with an offending path
will still return the bugged BBox.

Unfortunately, our test was checking just a path, while our actual code
was using a container with a path, resulting in our test failling to
detect the presence of the bug.

The simple solution is to update our test to more accurately reflect our
real-life use case.