### PR TITLE
Animate Angle Helper

### DIFF
--- a/core/ui/fields/field_angle_dropdown.js
+++ b/core/ui/fields/field_angle_dropdown.js
@@ -56,7 +56,7 @@ Blockly.FieldAngleDropdown.prototype.showEditor_ = function() {
     var menuItem = e.target;
     if (menuItem) {
       var value = menuItem.getValue();
-      this.angleHelper.setAngle(parseInt(value));
+      this.angleHelper.animateAngleChange(parseInt(value));
     }
   }.bind(this));
   return div;

--- a/core/ui/fields/field_angle_textinput.js
+++ b/core/ui/fields/field_angle_textinput.js
@@ -66,5 +66,5 @@ Blockly.FieldAngleTextInput.prototype.showEditor_ = function() {
 
 Blockly.FieldAngleTextInput.prototype.onHtmlInputChange_ = function(e) {
   Blockly.FieldAngleTextInput.superClass_.onHtmlInputChange_.call(this, e);
-  this.angleHelper.setAngle(parseInt(this.getText()));
+  this.angleHelper.animateAngleChange(parseInt(this.getText()));
 };


### PR DESCRIPTION
When the angle helper's angle is changed by an external field change,
smoothly animate the transition rather than jumping directly to the new
value.

### Before

![before](https://cloud.githubusercontent.com/assets/244100/20197098/8c9a3896-a752-11e6-832c-ea4b918bdac4.gif)

### After

![after](https://cloud.githubusercontent.com/assets/244100/20197134/b2767192-a752-11e6-9d12-74004b0cbea1.gif)

