### PR TITLE
Highlight Angler Helper's "primary" half

### DIFF
--- a/core/ui/fields/angle_helper.js
+++ b/core/ui/fields/angle_helper.js
@@ -112,8 +112,10 @@ Blockly.AngleHelper.prototype.init = function(svgContainer) {
     // define three marker sizes; 5px, 10px, and 15px at angles modulo
     // 15, 45, and 90 degrees, respectively.
     var markerSize = (angle % 90 == 0 ? 15 : angle % 45 == 0 ? 10 : 5);
+    var isOnPrimaryHalf = this.turnRight_ ? angle < 180 : angle > 180;
     Blockly.createSvgElement('line', {
       'stroke-linecap': 'round',
+      'stroke-opacity': isOnPrimaryHalf ? 1 : 0.3,
       'x1': this.center_.x + this.lineLength_.x,
       'y1': this.center_.y,
       'x2': this.center_.x + this.lineLength_.x - markerSize,


### PR DESCRIPTION
Rather than treating all 360 degrees of the angle helper as being equal,
subtly nudge the students toward making turns in the 0-180 region by
reducing the opacity of the tickmarks on the other half.

![image](https://cloud.githubusercontent.com/assets/244100/20198361/00d429a0-a759-11e6-8129-81817599462d.png)
![image](https://cloud.githubusercontent.com/assets/244100/20198372/15307692-a759-11e6-8f97-dcefd9365039.png)
