### PR TITLE
Fix block bumping on initialization

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -266,6 +266,7 @@ Blockly.Block.prototype.initSvg = function() {
   this.setCurrentlyHidden(this.currentlyHidden_);
   this.moveToFrontOfMainCanvas_();
   this.setIsUnused();
+  this.render();
 };
 
 /**

--- a/tests/blocks_test.js
+++ b/tests/blocks_test.js
@@ -26,6 +26,7 @@ function test_setBlockNotDisconnectable() {
 
   var blockSpace = Blockly.mainBlockSpace;
   var block1 = new Blockly.Block(blockSpace);
+  block1.setFunctional(true);
   block1.initSvg();
   var block2 = new Blockly.Block(blockSpace);
   block2.initSvg();


### PR DESCRIPTION
In a situation in which a top-level block with two input statements has
two or more blocks in the first one and a block containing a dropdown in
the second one, the blocks in the first statement end up getting bumped
out of position.

![image](https://cloud.githubusercontent.com/assets/244100/20233250/db438cd8-a822-11e6-89b9-ca7bb2260db0.png)

This is because the dropdown, upon initialization, checks for nearby
connections and bumps them away. And because the parent block is not yet
initialized when the dropdown block is being initialized, it sees the
blocks in the other statement as being positioned right on top of them,
and so bumps them away.

![image](https://cloud.githubusercontent.com/assets/244100/20233259/e7357a7e-a822-11e6-9882-f04c77041ab2.png)

Blocks with parents avoid this by being rendered before their children
get rendered, and top-level blocks with previous connections (ie, blocks
without parents that really should have parents) avoid this by making a
call to `setIsUnused` before initializing their children, which has the
side effect of making sure that they get rendered before their children
do.

![image](https://cloud.githubusercontent.com/assets/244100/20233267/f4821c8c-a822-11e6-9929-0a47b4bc30e3.png)

The simple solution is to make sure that _all_ blocks get rendered
before their children do, by adding a call to `this.render()` to the end
of `Block.initSvg`.

![image](https://cloud.githubusercontent.com/assets/244100/20233273/fe2949b8-a822-11e6-8d21-8d3dd40dae04.png)

