### PR TITLE
Optionally call changehandler in setTitleValue

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1844,6 +1844,12 @@ Blockly.Block.prototype.getTitleValue = function(name) {
  */
 Blockly.Block.prototype.setTitleValue = function(newValue, name) {
   var title = this.getTitle_(name);
+  if (title.changeHandler_) {
+    var override = title.changeHandler_(newValue);
+    if (override) {
+      newValue = override;
+    }
+  }
   if (title) {
     title.setValue(newValue);
   } else {

--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1844,7 +1844,7 @@ Blockly.Block.prototype.getTitleValue = function(name) {
  */
 Blockly.Block.prototype.setTitleValue = function(newValue, name) {
   var title = this.getTitle_(name);
-  if (title.changeHandler_) {
+  if (title.alwaysCallChangeHandler && title.changeHandler_) {
     var override = title.changeHandler_(newValue);
     if (override) {
       newValue = override;

--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1844,12 +1844,6 @@ Blockly.Block.prototype.getTitleValue = function(name) {
  */
 Blockly.Block.prototype.setTitleValue = function(newValue, name) {
   var title = this.getTitle_(name);
-  if (title.alwaysCallChangeHandler && title.changeHandler_) {
-    var override = title.changeHandler_(newValue);
-    if (override) {
-      newValue = override;
-    }
-  }
   if (title) {
     title.setValue(newValue);
   } else {

--- a/core/ui/fields/field_dropdown.js
+++ b/core/ui/fields/field_dropdown.js
@@ -93,8 +93,9 @@ Blockly.FieldDropdown.prototype.showEditor_ = function(container) {
     var menuItem = e.target;
     if (menuItem) {
       var value = menuItem.getValue();
-      if (thisField.changeHandler_) {
-        // Call any change handler, and allow it to override.
+      if (thisField.changeHandler_ && !thisField.alwaysCallChangeHandler_) {
+        // Call any change handler, and allow it to override. This happens
+        // inside setValue if alwaysCallChangeHandler_ is true.
         var override = thisField.changeHandler_(value);
         if (override !== undefined) {
           value = override;
@@ -247,7 +248,7 @@ Blockly.FieldDropdown.prototype.getValue = function() {
 Blockly.FieldDropdown.prototype.setValue = function(newValue) {
   if (this.alwaysCallChangeHandler_ && this.changeHandler_) {
     var override = this.changeHandler_(newValue);
-    if (override) {
+    if (override !== undefined) {
       newValue = override;
     }
   }

--- a/core/ui/fields/field_dropdown.js
+++ b/core/ui/fields/field_dropdown.js
@@ -48,7 +48,7 @@ Blockly.FieldDropdown = function(menuGenerator, opt_changeHandler,
     [[Blockly.FieldDropdown.NO_OPTIONS_MESSAGE,
       Blockly.FieldDropdown.NO_OPTIONS_MESSAGE]];
   this.changeHandler_ = opt_changeHandler;
-  this.alwaysCallChangeHandler = !!opt_alwaysCallChangeHandler;
+  this.alwaysCallChangeHandler_ = !!opt_alwaysCallChangeHandler;
   this.trimOptions_();
   var firstTuple = this.getOptions()[0];
   this.value_ = firstTuple[1];
@@ -245,6 +245,12 @@ Blockly.FieldDropdown.prototype.getValue = function() {
  * @param {string} newValue New value to set.
  */
 Blockly.FieldDropdown.prototype.setValue = function(newValue) {
+  if (this.alwaysCallChangeHandler_ && this.changeHandler_) {
+    var override = this.changeHandler_(newValue);
+    if (override) {
+      newValue = override;
+    }
+  }
   this.value_ = newValue;
   // Look up and display the human-readable text.
   var options = this.getOptions();

--- a/core/ui/fields/field_dropdown.js
+++ b/core/ui/fields/field_dropdown.js
@@ -36,14 +36,19 @@ goog.require('goog.array');
  *     for a dropdown list, or a function which generates these options.
  * @param {Function} opt_changeHandler A function that is executed when a new
  *     option is selected.
+ * @param {boolean} opt_alwaysCallChangeHandler Whether or not to call
+ *     opt_changeHandler when the value is set by something other than UI
+ *     interaction
  * @extends {Blockly.Field}
  * @constructor
  */
-Blockly.FieldDropdown = function(menuGenerator, opt_changeHandler) {
+Blockly.FieldDropdown = function(menuGenerator, opt_changeHandler,
+    opt_alwaysCallChangeHandler) {
   this.menuGenerator_ = menuGenerator ||
     [[Blockly.FieldDropdown.NO_OPTIONS_MESSAGE,
       Blockly.FieldDropdown.NO_OPTIONS_MESSAGE]];
   this.changeHandler_ = opt_changeHandler;
+  this.alwaysCallChangeHandler = !!opt_alwaysCallChangeHandler;
   this.trimOptions_();
   var firstTuple = this.getOptions()[0];
   this.value_ = firstTuple[1];


### PR DESCRIPTION
FieldDropdown's `changeHandler` is currently only called when the dropdown's value is changed through UI interaction. I'm adding an option to call it when it's changed by a call to `setTitleValue` as well.

I'll be using this option to fix the "Text in “When Any <X>” block doesn’t get properly updated on refresh" bug.