### PR TITLE
Reposition fields on scroll

### DIFF
--- a/core/ui/block_space/block_space.js
+++ b/core/ui/block_space/block_space.js
@@ -125,6 +125,7 @@ Blockly.BlockSpace.EVENTS.EVENT_BLOCKS_IMPORTED = 'blocksImported';
  * @type {string}
  */
 Blockly.BlockSpace.EVENTS.BLOCK_SPACE_CHANGE = 'blockSpaceChange';
+Blockly.BlockSpace.EVENTS.BLOCK_SPACE_SCROLLED = 'blockSpaceScrolled';
 
 /**
  * Fired by Code Studio when the run button is clicked.
@@ -1138,6 +1139,7 @@ Blockly.BlockSpace.prototype.scrollTo = function (newScrollX, newScrollY) {
 
   // Set the scrollbar position, which will auto-scroll the canvas
   this.scrollbarPair.set(newScrollX, newScrollY);
+  this.events.dispatchEvent(Blockly.BlockSpace.EVENTS.BLOCK_SPACE_SCROLLED);
 };
 
 /**

--- a/core/ui/fields/field.js
+++ b/core/ui/fields/field.js
@@ -374,3 +374,43 @@ Blockly.Field.prototype.onClick_ = function(e) {
 Blockly.Field.prototype.setTooltip = function(newTip) {
   // Non-abstract sub-classes may wish to implement this.  See FieldLabel.
 };
+
+Blockly.Field.prototype.positionWidgetDiv = function() {
+  // intentional noop; overridden by child classes
+};
+
+Blockly.Field.prototype.showWidgetDiv_ = function() {
+  Blockly.WidgetDiv.show(this, this.generateWidgetDisposeHandler_());
+
+  // if we are attached to a block, recalculate our position when the
+  // block's blockspace gets scrolled.
+  if (this.sourceBlock_ &&
+      this.sourceBlock_.blockSpace &&
+      this.sourceBlock_.blockSpace.events) {
+    var events = this.sourceBlock_.blockSpace.events;
+
+    if (!this.blockSpaceScrolledListenKey_) {
+      this.blockSpaceScrolledListenKey_ = events.listen(
+          Blockly.BlockSpace.EVENTS.BLOCK_SPACE_SCROLLED,
+          this.positionWidgetDiv.bind(this));
+    }
+  }
+};
+
+/**
+ * Generates a function which will be called when the widget is closed,
+ * to be used as an onDispose handler.
+ * @return {function}
+ */
+Blockly.Field.prototype.generateWidgetDisposeHandler_ = function() {
+  return function () {
+    if (this.blockSpaceScrolledListenKey_ &&
+        this.sourceBlock_ &&
+        this.sourceBlock_.blockSpace &&
+        this.sourceBlock_.blockSpace.events) {
+      this.sourceBlock_.blockSpace.events.unlistenByKey(
+          this.blockSpaceScrolledListenKey_);
+      this.blockSpaceScrolledListenKey_ = null;
+    }
+  }.bind(this);
+};

--- a/core/ui/fields/field_colour.js
+++ b/core/ui/fields/field_colour.js
@@ -98,7 +98,7 @@ Blockly.FieldColour.COLUMNS = 7;
  * @private
  */
 Blockly.FieldColour.prototype.showEditor_ = function() {
-  Blockly.WidgetDiv.show(this, Blockly.FieldColour.widgetDispose_);
+  this.showWidgetDiv_();
   var div = Blockly.WidgetDiv.DIV;
   // Create the palette using Closure.
   var picker = new goog.ui.ColorPicker();
@@ -107,30 +107,7 @@ Blockly.FieldColour.prototype.showEditor_ = function() {
   picker.render(div);
   picker.setSelectedColor(this.getValue());
 
-  // Position the palette to line up with the field.
-  var xy = Blockly.getAbsoluteXY_(/** @type {!Element} */ (this.borderRect_), this.
-    getRootSVGElement_());
-  if (navigator.userAgent.indexOf("MSIE") >= 0 || navigator.userAgent.indexOf("Trident") >= 0) {
-      this.borderRect_.style.display = "inline";   /* reqd for IE */
-      var borderBBox = {
-          x: this.borderRect_.getBBox().x,
-          y: this.borderRect_.getBBox().y,
-          width: this.borderRect_.scrollWidth,
-          height: this.borderRect_.scrollHeight
-      };
-  }
-  else {
-      var borderBBox = this.borderRect_.getBBox();
-  }
-  if (Blockly.RTL) {
-    xy.x += borderBBox.width;
-  }
-  xy.y += borderBBox.height - 1;
-  if (Blockly.RTL) {
-    xy.x -= div.offsetWidth;
-  }
-  div.style.left = xy.x + 'px';
-  div.style.top = xy.y + 'px';
+  this.positionWidgetDiv();
 
   // Configure event handler.
   var thisObj = this;
@@ -153,11 +130,47 @@ Blockly.FieldColour.prototype.showEditor_ = function() {
 };
 
 /**
- * Hide the colour palette.
- * @private
+ * @override
  */
-Blockly.FieldColour.widgetDispose_ = function() {
-  if (Blockly.FieldColour.changeEventKey_) {
-    goog.events.unlistenByKey(Blockly.FieldColour.changeEventKey_);
+Blockly.FieldColour.prototype.positionWidgetDiv = function() {
+  // Position the palette to line up with the field.
+  var xy = Blockly.getAbsoluteXY_(/** @type {!Element} */ (this.borderRect_), this.
+    getRootSVGElement_());
+  if (navigator.userAgent.indexOf("MSIE") >= 0 || navigator.userAgent.indexOf("Trident") >= 0) {
+      this.borderRect_.style.display = "inline";   /* reqd for IE */
+      var borderBBox = {
+          x: this.borderRect_.getBBox().x,
+          y: this.borderRect_.getBBox().y,
+          width: this.borderRect_.scrollWidth,
+          height: this.borderRect_.scrollHeight
+      };
   }
+  else {
+      var borderBBox = this.borderRect_.getBBox();
+  }
+  if (Blockly.RTL) {
+    xy.x += borderBBox.width;
+  }
+  xy.y += borderBBox.height - 1;
+  if (Blockly.RTL) {
+    xy.x -= div.offsetWidth;
+  }
+
+  var windowSize = goog.dom.getViewportSize();
+  var scrollOffset = goog.style.getViewportPageOffset(document);
+  Blockly.WidgetDiv.position(xy.x, xy.y, windowSize, scrollOffset);
+}
+
+/**
+ * Hide the colour palette.
+ * @override
+ */
+Blockly.FieldColour.prototype.generateWidgetDisposeHandler_ = function() {
+  var superWidgetDisposeHandler_ = Blockly.FieldRectangularDropdown.superClass_.generateWidgetDisposeHandler_.call(this);
+  return function() {
+    superWidgetDisposeHandler_();
+    if (Blockly.FieldColour.changeEventKey_) {
+      goog.events.unlistenByKey(Blockly.FieldColour.changeEventKey_);
+    }
+  }.bind(this);
 };

--- a/core/ui/fields/field_dropdown.js
+++ b/core/ui/fields/field_dropdown.js
@@ -86,7 +86,7 @@ Blockly.FieldDropdown.prototype.CURSOR = 'default';
  * @private
  */
 Blockly.FieldDropdown.prototype.showEditor_ = function(container) {
-  Blockly.WidgetDiv.show(this, null);
+  this.showWidgetDiv_();
   var thisField = this;
 
   function callback(e) {
@@ -120,11 +120,6 @@ Blockly.FieldDropdown.prototype.showEditor_ = function(container) {
     menuItem.setChecked(value === this.value_);
   }
   goog.events.listen(this.menu_, goog.ui.Component.EventType.ACTION, callback);
-  // Record windowSize and scrollOffset before adding menu.
-  var windowSize = goog.dom.getViewportSize();
-  var scrollOffset = goog.style.getViewportPageOffset(document);
-  var xy = Blockly.getAbsoluteXY_(/** @type {!Element} */ (this.borderRect_), this.getRootSVGElement_());
-  var borderBBox = this.borderRect_.getBBox();
   var div = container || Blockly.WidgetDiv.DIV;
 
   // IE will scroll the bottom of the page into view to show this element
@@ -142,10 +137,21 @@ Blockly.FieldDropdown.prototype.showEditor_ = function(container) {
   menuDom.style.overflowY = "auto";
   menuDom.style["max-height"] = "250px";
 
-  // Record menuSize after adding menu.
-  var menuSize = goog.style.getSize(menuDom);
+  this.positionWidgetDiv();
 
-  // Position the menu.
+  div.style.visibility = "visible";
+};
+
+/**
+ * @override
+ */
+Blockly.FieldDropdown.prototype.positionWidgetDiv = function() {
+  var windowSize = goog.dom.getViewportSize();
+  var scrollOffset = goog.style.getViewportPageOffset(document);
+  var xy = Blockly.getAbsoluteXY_(/** @type {!Element} */ (this.borderRect_), this.getRootSVGElement_());
+  var borderBBox = this.borderRect_.getBBox();
+  var menuSize = goog.style.getSize(this.menu_.getElement());
+
   // Flip menu vertically if off the bottom.
   if (xy.y + menuSize.height + borderBBox.height >=
       windowSize.height + scrollOffset.y) {
@@ -177,8 +183,7 @@ Blockly.FieldDropdown.prototype.showEditor_ = function(container) {
   }
 
   Blockly.WidgetDiv.position(xy.x, xy.y, windowSize, scrollOffset);
-  div.style.visibility = "visible";
-};
+}
 
 /**
  * Factor out common words in statically defined options.

--- a/core/ui/fields/field_rectangular_dropdown.js
+++ b/core/ui/fields/field_rectangular_dropdown.js
@@ -158,7 +158,7 @@ Blockly.FieldRectangularDropdown.prototype.setArrowDirection_ = function(up) {
 };
 
 Blockly.FieldRectangularDropdown.prototype.showMenu_ = function() {
-  Blockly.WidgetDiv.show(this, this.generateMenuClosedHandler_());
+  this.showWidgetDiv_();
   this.menu_ = this.createMenuWithChoices_(this.choices_);
   goog.events.listen(this.menu_, goog.ui.Component.EventType.ACTION, this.generateMenuItemSelectedHandler_());
   this.addPositionAndShowMenu(this.menu_);
@@ -166,10 +166,6 @@ Blockly.FieldRectangularDropdown.prototype.showMenu_ = function() {
 };
 
 Blockly.FieldRectangularDropdown.prototype.hideMenu_ = function() {
-  if (this.blockSpaceScrolledListenKey_) {
-    this.sourceBlock_.blockSpace.events.unlistenByKey(this.blockSpaceScrolledListenKey_);
-    this.blockSpaceScrolledListenKey_ = null;
-  }
 
   this.pointArrowDown_();
 };
@@ -222,11 +218,15 @@ Blockly.FieldRectangularDropdown.prototype.generateMenuItemSelectedHandler_ = fu
   };
 };
 
-Blockly.FieldRectangularDropdown.prototype.generateMenuClosedHandler_ = function () {
-  var fieldRectangularDropdown = this;
+/**
+ * @override
+ */
+Blockly.FieldRectangularDropdown.prototype.generateWidgetDisposeHandler_ = function () {
+  var superWidgetDisposeHandler_ = Blockly.FieldRectangularDropdown.superClass_.generateWidgetDisposeHandler_.call(this);
   return function() {
-    fieldRectangularDropdown.hideMenu_();
-  };
+    superWidgetDisposeHandler_();
+    this.hideMenu_();
+  }.bind(this);
 };
 
 Blockly.FieldRectangularDropdown.prototype.addPositionAndShowMenu = function (menu) {
@@ -258,30 +258,23 @@ Blockly.FieldRectangularDropdown.prototype.addPositionAndShowMenu = function (me
     Blockly.addClass_(menuDom, 'blocklyGridDropdownMenu');
   }
 
-  var positionBelow = multipleColumns;
-  this.updatePosition(positionBelow);
-
-  // if we are attached to a block, recalculate our position when the
-  // block's blockspace gets scrolled.
-  if (this.sourceBlock_) {
-    var events = this.sourceBlock_.blockSpace.events;
-
-    if (!this.blockSpaceScrolledListenKey_) {
-      this.blockSpaceScrolledListenKey_ = events.listen(
-        Blockly.BlockSpace.EVENTS.BLOCK_SPACE_SCROLLED,
-        this.updatePosition.bind(this, positionBelow)
-      );
-    }
-  }
+  this.positionWidgetDiv();
 
   widgetDiv.style.visibility = "visible";
 };
 
-Blockly.FieldRectangularDropdown.prototype.updatePosition = function (positionBelow) {
+/**
+ * @override
+ */
+Blockly.FieldRectangularDropdown.prototype.positionWidgetDiv = function () {
+  var numberOfColumns = chooseNumberOfColumns(this.menu_.getChildCount());
+  var positionBelow = numberOfColumns > 1;
+
+  var menuPosition = this.calculateMenuPosition_(this.previewElement_, positionBelow);
+
   var windowSize = goog.dom.getViewportSize();
   var scrollOffset = goog.style.getViewportPageOffset(document);
 
-  var menuPosition = this.calculateMenuPosition_(this.previewElement_, positionBelow);
   Blockly.WidgetDiv.position(menuPosition.x, menuPosition.y, windowSize, scrollOffset);
 };
 

--- a/core/ui/fields/field_rectangular_dropdown.js
+++ b/core/ui/fields/field_rectangular_dropdown.js
@@ -166,7 +166,6 @@ Blockly.FieldRectangularDropdown.prototype.showMenu_ = function() {
 };
 
 Blockly.FieldRectangularDropdown.prototype.hideMenu_ = function() {
-
   this.pointArrowDown_();
 };
 

--- a/tests/blockly_test.html
+++ b/tests/blockly_test.html
@@ -24,5 +24,6 @@
     <script type="text/javascript" src="unused_blocks_test.js"></script>
     <script type="text/javascript" src="utils_test.js"></script>
     <script type="text/javascript" src="angle_helper_test.js"></script>
+    <script type="text/javascript" src="fields_test.js"></script>
   </body>
 </html>

--- a/tests/fields_test.js
+++ b/tests/fields_test.js
@@ -56,9 +56,9 @@ function test_field_reposition_on_scroll() {
   var block = blockSpace.getTopBlocks()[0];
   var field = block.getTitle_("NUM");
 
-  window.positionWidgetDivCalled = false;
+  var positionWidgetDivCalled = false;
   field.positionWidgetDiv = function () {
-    window.positionWidgetDivCalled = true;
+    positionWidgetDivCalled = true;
   };
 
   // Widget will not be positioned until the field is opened, even if
@@ -70,7 +70,7 @@ function test_field_reposition_on_scroll() {
   assertEquals(positionWidgetDivCalled, true);
 
   // It will then be positioned again once the block space is scrolled
-  window.positionWidgetDivCalled = false;
+  positionWidgetDivCalled = false;
   blockSpace.events.dispatchEvent(Blockly.BlockSpace.EVENTS.BLOCK_SPACE_SCROLLED);
   assertEquals(positionWidgetDivCalled, true);
 

--- a/tests/fields_test.js
+++ b/tests/fields_test.js
@@ -1,0 +1,78 @@
+/* global Blockly, goog */
+/* global assert, assertNull, assertNotNull, assertEquals, assertFalse */
+'use strict';
+
+function test_field_scroll_listener() {
+  var containerDiv = Blockly.Test.initializeBlockSpaceEditor();
+  var blockSpace = Blockly.mainBlockSpace;
+
+  // We begin with no onscroll listeners
+  assertEquals(0, blockSpace.events.getListeners(Blockly.BlockSpace.EVENTS.BLOCK_SPACE_SCROLLED, false).length);
+
+  Blockly.Xml.domToBlockSpace(blockSpace, Blockly.Xml.textToDom(
+      '<xml>' +
+      '  <block type="math_number">' +
+      '    <title name="NUM">0</title>' +
+      '  </block>' +
+      '</xml>'));
+
+  var block = blockSpace.getTopBlocks()[0];
+  var field = block.getTitle_("NUM");
+
+  // Still none after creation of block with field
+  assertEquals(0, blockSpace.events.getListeners(Blockly.BlockSpace.EVENTS.BLOCK_SPACE_SCROLLED, false).length);
+
+  // The field also has no internal knowledge of listeners
+  assertEquals(undefined, field.blockSpaceScrolledListenKey_);
+
+  // Open the field!
+  Blockly.fireTestClickSequence(field.fieldGroup_);
+
+  // We now have both a listener and a listener key
+  assert(field.blockSpaceScrolledListenKey_ != undefined);
+  assertEquals(1, blockSpace.events.getListeners(Blockly.BlockSpace.EVENTS.BLOCK_SPACE_SCROLLED, false).length);
+
+  // Close the field
+  Blockly.fireTestClickSequence(blockSpace.svgGroup_);
+
+  // Listener and key are now both gone
+  assertEquals(0, blockSpace.events.getListeners(Blockly.BlockSpace.EVENTS.BLOCK_SPACE_SCROLLED, false).length);
+  assertNull(field.blockSpaceScrolledListenKey_);
+
+  goog.dom.removeNode(containerDiv);
+}
+
+function test_field_reposition_on_scroll() {
+  var containerDiv = Blockly.Test.initializeBlockSpaceEditor();
+  var blockSpace = Blockly.mainBlockSpace;
+
+  Blockly.Xml.domToBlockSpace(blockSpace, Blockly.Xml.textToDom(
+      '<xml>' +
+      '  <block type="math_number">' +
+      '    <title name="NUM">0</title>' +
+      '  </block>' +
+      '</xml>'));
+
+  var block = blockSpace.getTopBlocks()[0];
+  var field = block.getTitle_("NUM");
+
+  window.positionWidgetDivCalled = false;
+  field.positionWidgetDiv = function () {
+    window.positionWidgetDivCalled = true;
+  };
+
+  // Widget will not be positioned until the field is opened, even if
+  // the block space is scrolled
+  assertEquals(positionWidgetDivCalled, false);
+  blockSpace.events.dispatchEvent(Blockly.BlockSpace.EVENTS.BLOCK_SPACE_SCROLLED);
+  assertEquals(positionWidgetDivCalled, false);
+  Blockly.fireTestClickSequence(field.fieldGroup_);
+  assertEquals(positionWidgetDivCalled, true);
+
+  // It will then be positioned again once the block space is scrolled
+  window.positionWidgetDivCalled = false;
+  blockSpace.events.dispatchEvent(Blockly.BlockSpace.EVENTS.BLOCK_SPACE_SCROLLED);
+  assertEquals(positionWidgetDivCalled, true);
+
+  goog.dom.removeNode(containerDiv);
+}


### PR DESCRIPTION
Most (all?) of our editable fields in blockly don't reposition
themselves when the blockspace scrolls. (You can see an example of this [here](https://studio.code.org/s/grade1/stage/12/puzzle/9)) This solution adds a scroll
event which they can listen to to update themselves.

TODO: apply this approach to all fields, not just the rectangular
dropdown.