### PR TITLE
Stop running bumpNeighbours for blocks being dragged in from the toolbox

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -81,6 +81,7 @@ Blockly.Block = function(blockSpace, prototypeName, htmlId) {
   this.nextConnectionDisabled_ = false;
   this.collapsed_ = false;
   this.dragging_ = false;
+  this.bumpingEnabled_ = true;
 
   // Used to hide function blocks when not in modal workspace. This property
   // is not serialized/deserialized.
@@ -1290,13 +1291,21 @@ Blockly.Block.prototype.generateReconnector_ = function(earlierConnection) {
   };
 };
 
+Blockly.Block.prototype.enableBumping = function() {
+  this.bumpingEnabled_ = true;
+};
+
+Blockly.Block.prototype.disableBumping = function() {
+  this.bumpingEnabled_ = false;
+};
+
 /**
  * Bump unconnected blocks out of alignment.  Two blocks which aren't actually
  * connected should not coincidentally line up on screen.
  * @private
  */
 Blockly.Block.prototype.bumpNeighbours_ = function() {
-  if (Blockly.Block.isDragging() || !Blockly.BUMP_UNCONNECTED) {
+  if (Blockly.Block.isDragging() || !Blockly.BUMP_UNCONNECTED || !this.bumpingEnabled_) {
     // Don't bump blocks during a drag.
     return;
   }

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -697,7 +697,7 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
     // Create the new block by cloning the block in the flyout (via XML).
     var xml = Blockly.Xml.blockToDom(originBlock);
     var targetBlockSpace = flyout.targetBlockSpace_;
-    var block = Blockly.Xml.domToBlock(targetBlockSpace, xml);
+    var block = Blockly.Xml.domToBlock(targetBlockSpace, xml, true /* dragging */);
     // Place it in the same spot as the flyout copy.
     var svgRootOld = originBlock.getSvgRoot();
     if (!svgRootOld) {

--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -328,13 +328,18 @@ Blockly.Xml.domToBlockSpace = function(blockSpace, xml) {
  * blockSpace.
  * @param {!Blockly.BlockSpace} blockSpace The blockSpace.
  * @param {!Element} xmlBlock XML block element.
+ * @param {boolean=} dragging Whether the new block is going to be dragging
+ *   upon creation.
  * @return {!Blockly.Block} The root block created.
  */
-Blockly.Xml.domToBlock = function(blockSpace, xmlBlock) {
+Blockly.Xml.domToBlock = function(blockSpace, xmlBlock, dragging) {
   var prototypeName = xmlBlock.getAttribute('type');
   var id = xmlBlock.getAttribute('id');
   var block = new Blockly.Block(blockSpace, prototypeName, id);
   block.initSvg();
+  if (dragging) {
+    block.disableBumping();
+  }
 
   var inline = xmlBlock.getAttribute('inline');
   if (inline) {
@@ -482,6 +487,7 @@ Blockly.Xml.domToBlock = function(blockSpace, xmlBlock) {
   } else {
     block.render();
   }
+  block.enableBumping();
   return block;
 };
 


### PR DESCRIPTION
Right now, dragging certain blocks in from the toolbox causes existing blocks at the top left of the workspace to get bumped out of position. This happens the moment you mousedown on the toolbox block, not when you place it somewhere (which is when neighbor bumping is supposed to happen).

This happens because `bumpNeighbours_` is called indirectly by `domToBlock` while the newly created block is still sitting at `0,0`. `bumpNeighbors_` normally terminates immediately during block dragging, but the `onMouseDown` handler doesn't have a chance to run until the block is initialized, so I'm making `domToBlock` temporarily disable block bumping when needed.