### PR TITLE
Set dragmode before creating block to stop unnecessary neighbour bump

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -299,6 +299,15 @@ Blockly.Block.isFreelyDragging = function() {
 };
 
 /**
+ * Pretend that we've already started dragging a block. This ensures that any
+ * methods called between now and onMouseDown behave as though a block is being
+ * dragged, e.g. skipping neighbour bumping.
+ */
+Blockly.Block.startDragging = function() {
+  Blockly.Block.dragMode_ = Blockly.Block.DRAG_MODE_INSIDE_STICKY_RADIUS;
+}
+
+/**
  * Wrapper function called when a mouseUp occurs during a drag operation.
  * @type {BindData}
  * @private

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -697,6 +697,7 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
     // Create the new block by cloning the block in the flyout (via XML).
     var xml = Blockly.Xml.blockToDom(originBlock);
     var targetBlockSpace = flyout.targetBlockSpace_;
+    Blockly.Block.startDragging();
     var block = Blockly.Xml.domToBlock(targetBlockSpace, xml);
     // Place it in the same spot as the flyout copy.
     var svgRootOld = originBlock.getSvgRoot();


### PR DESCRIPTION
Right now, dragging certain blocks in from the toolbox causes existing blocks at the top left of the workspace to get bumped out of position. This happens the moment you mousedown on the toolbox block, not when you place it somewhere (which is when neighbor bumping is supposed to happen).

This happens because `bumpNeighbours_` is called indirectly by `domToBlock` while the newly created block is still sitting at `0,0`. `bumpNeighbors_` normally terminates immediately during block dragging, but the onMouseDown handler doesn't have a chance to run until the block is initialized. Instead, I'm setting the dragMode before creating the block.

Immediately setting it to `DRAG_MODE_FREELY_DRAGGING` breaks stuff, because that makes onMouseDown attempt to terminate the preceding drag, using a bunch of properties that haven't been correctly set yet. Setting the dragMode to `DRAG_MODE_INSIDE_STICKY_RADIUS` skips all that, and works just fine.