### PR TITLE
Size RTL dropdowns appropriately

### DIFF
--- a/core/ui/css.js
+++ b/core/ui/css.js
@@ -826,8 +826,11 @@ Blockly.Css.CONTENT = [
    * If a menu doesn't have items with shortcuts, leave just enough room for
    * submenu arrows, if they are rendered.
    */
-  '.goog-menu-noaccel .goog-menuitem {',
+  '.goog-menu-noaccel .goog-menuitem:not(.goog-menuitem-rtl) {',
   '  padding-right: 20px;',
+  '}',
+  '.goog-menu-noaccel .goog-menuitem.goog-menuitem-rtl {',
+  '  padding-left: 20px;',
   '}',
 
   '.goog-menuitem-content {',


### PR DESCRIPTION
Some custom CSS was overriding styles for a certain class of dropdowns,
but not doing so in an RTL-aware way. It now is.

Before | After
--- | ---
![image](https://cloud.githubusercontent.com/assets/244100/21628821/49de1f72-d1d7-11e6-9464-78f7a3d4bd47.png) | ![image](https://cloud.githubusercontent.com/assets/244100/21628818/4350cac4-d1d7-11e6-8321-2f156fe0ce9e.png)

Fixes (part of) [axos: 571](https://codeorg.axosoft.com/viewitem?id=571)