### PR TITLE
Add 'mainBlockSpace created' event

### DIFF
--- a/core/initialization/inject.js
+++ b/core/initialization/inject.js
@@ -67,6 +67,7 @@ Blockly.inject = function(container, opt_options, opt_audioPlayer) {
    * @type {Blockly.BlockSpace}
    */
   Blockly.mainBlockSpace = Blockly.mainBlockSpaceEditor.blockSpace;
+  Blockly.fireUiEvent(document, Blockly.BlockSpace.EVENTS.MAIN_BLOCK_SPACE_CREATED);
 
   if (Blockly.useModalFunctionEditor) {
     /** @type {Blockly.FunctionEditor} */

--- a/core/ui/block_space/block_space.js
+++ b/core/ui/block_space/block_space.js
@@ -114,6 +114,15 @@ Blockly.BlockSpace.DEBUG_EVENTS = false;
 Blockly.BlockSpace.EVENTS = {};
 
 /**
+ * Called after the mainBlockSpace has been initialized and assigned to
+ * the Blockly.mainBlockSpace global attribute; can be used by
+ * components that want to make their own one-off blockspaces to ensure
+ * that they're preserving initialization order.
+ * @type {string}
+ */
+Blockly.BlockSpace.EVENTS.MAIN_BLOCK_SPACE_CREATED = 'mainBlockSpaceCreated';
+
+/**
  * Called after a blockspace has been populated with a set of blocks
  * (e.g. when using domToBlockSpace)
  * @type {string}


### PR DESCRIPTION
So other blockspaces on the page can make sure all the "special"
initialization has been done before they let themselves be created