### PR TITLE
Add option to disable editing of the number of branches in an if/else block

### DIFF
--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -40,8 +40,12 @@ Blockly.Blocks.controls_if = {
         .appendTitle(Blockly.Msg.CONTROLS_IF_MSG_THEN);
     this.setPreviousStatement(true);
     this.setNextStatement(true);
-    this.setMutator(new Blockly.Mutator(['controls_if_elseif',
-                                         'controls_if_else']));
+    if (!Blockly.disableIfElseEditing) {
+      this.setMutator(new Blockly.Mutator([
+        'controls_if_elseif',
+        'controls_if_else'
+      ]));
+    }
     // Assign 'this' to a variable for use in the tooltip closure below.
     var thisBlock = this;
     this.setTooltip(function() {

--- a/core/initialization/inject.js
+++ b/core/initialization/inject.js
@@ -156,6 +156,7 @@ Blockly.parseOptions_ = function(options) {
     hasTrashcan: hasTrashcan,
     varsInGlobals: options['varsInGlobals'] || false,
     languageTree: tree,
+    disableIfElseEditing: options['disableIfElseEditing'] || false,
     disableParamEditing: options['disableParamEditing'] || false,
     disableVariableEditing: options['disableVariableEditing'] || false,
     useModalFunctionEditor: options['useModalFunctionEditor'] || false,


### PR DESCRIPTION
Following the pattern of `Blockly.disableParamEditing`.