### PR TITLE
Fix FieldTextInput in RTL

### DIFF
--- a/core/ui/fields/field_textinput.js
+++ b/core/ui/fields/field_textinput.js
@@ -226,7 +226,7 @@ Blockly.FieldTextInput.prototype.positionWidgetDiv = function() {
           var borderBBox = this.borderRect_.getBBox();
       }
     xy.x += borderBBox.width;
-    xy.x -= div.offsetWidth;
+    xy.x -= Blockly.WidgetDiv.DIV.offsetWidth;
   }
   // Shift by a few pixels to line up exactly.
   xy.y += 1;


### PR DESCRIPTION
A recent refactor of blockly's WidgetDiv positioning implementation
broke textinputs in RTL mode by removing a variable declaration; this
simply restores it.