### PR TITLE
Move blocks to a top-level SVG while dragging

### DIFF
--- a/core/ui/block_space/block_space.js
+++ b/core/ui/block_space/block_space.js
@@ -337,7 +337,7 @@ Blockly.BlockSpace.prototype.createDom = function() {
       id: 'blocklyDragCanvas',
       width: '100%',
       height: '100%',
-      style: 'pointer-events: none; position: absolute; top: 0; left: 0;'
+      style: 'pointer-events: none; position: absolute; top: 0; left: 0; z-index: 10;'
     }, document.body);
   }
   this.svgDragCanvas_ = Blockly.createSvgElement('g', {'class': 'svgDragCanvas'}, Blockly.dragSvg);

--- a/core/ui/block_space/block_space.js
+++ b/core/ui/block_space/block_space.js
@@ -328,9 +328,22 @@ Blockly.BlockSpace.prototype.createDom = function() {
   this.svgGroup_ = Blockly.createSvgElement('g', {'class': 'svgGroup'}, null);
   this.clippingGroup_ = Blockly.createSvgElement('g', {'class': 'svgClippingGroup'}, this.svgGroup_);
   this.svgBlockCanvas_ = Blockly.createSvgElement('g', {'class': 'svgBlockCanvas'}, this.clippingGroup_);
-  this.svgDragCanvas_ = Blockly.createSvgElement('g', {'class': 'svgDragCanvas'}, this.svgGroup_);
   this.svgBubbleCanvas_ = Blockly.createSvgElement('g', {'class': 'svgBubbleCanvas'}, this.svgGroup_);
   this.svgDebugCanvas_ = Blockly.createSvgElement('g', {'class': 'svgDebugCanvas'}, this.svgGroup_);
+
+  // Create a separate SVG to contain blocks while dragging.
+  if (!Blockly.dragSvg) {
+    Blockly.dragSvg = Blockly.createSvgElement('svg', {
+      id: 'blocklyDragCanvas',
+      width: '100%',
+      height: '100%',
+      style: 'pointer-events: none; position: absolute; top: 0; left: 0;'
+    }, document.body);
+
+    Blockly.dragCanvas = Blockly.createSvgElement('g', {'class': 'svgDragCanvas'}, Blockly.dragSvg);
+  }
+  this.svgDragCanvas_ = Blockly.dragCanvas;
+
   this.fireChangeEvent();
   return this.svgGroup_;
 };

--- a/core/ui/block_space/block_space.js
+++ b/core/ui/block_space/block_space.js
@@ -339,10 +339,8 @@ Blockly.BlockSpace.prototype.createDom = function() {
       height: '100%',
       style: 'pointer-events: none; position: absolute; top: 0; left: 0;'
     }, document.body);
-
-    Blockly.dragCanvas = Blockly.createSvgElement('g', {'class': 'svgDragCanvas'}, Blockly.dragSvg);
   }
-  this.svgDragCanvas_ = Blockly.dragCanvas;
+  this.svgDragCanvas_ = Blockly.createSvgElement('g', {'class': 'svgDragCanvas'}, Blockly.dragSvg);
 
   this.fireChangeEvent();
   return this.svgGroup_;
@@ -372,6 +370,9 @@ Blockly.BlockSpace.prototype.dispose = function() {
   if (this.svgGroup_) {
     goog.dom.removeNode(this.svgGroup_);
     this.svgGroup_ = null;
+  }
+  if (this.svgDragCanvas_) {
+    goog.dom.removeNode(this.svgDragCanvas_);
   }
   this.svgBlockCanvas_ = null;
   this.svgDragCanvas_ = null;

--- a/core/ui/block_space/block_space_editor.js
+++ b/core/ui/block_space/block_space_editor.js
@@ -915,12 +915,14 @@ Blockly.BlockSpaceEditor.prototype.setBlockSpaceMetrics_ = function(xyRatio) {
   if (goog.isNumber(xyRatio.y)) {
     this.blockSpace.yOffsetFromView = -blockSpaceSize.height * xyRatio.y;
   }
-  var translation = 'translate(' +
-    (this.blockSpace.xOffsetFromView + metrics.absoluteLeft) + ',' +
-    (this.blockSpace.yOffsetFromView + metrics.absoluteTop) + ')';
+  var x = this.blockSpace.xOffsetFromView + metrics.absoluteLeft;
+  var y = this.blockSpace.yOffsetFromView + metrics.absoluteTop;
+  var translation = 'translate(' + x + ',' + y + ')';
   this.blockSpace.getCanvas().setAttribute('transform', translation);
-  this.blockSpace.getDragCanvas().setAttribute('transform', translation);
   this.blockSpace.getBubbleCanvas().setAttribute('transform', translation);
+
+  var offset = Blockly.convertCoordinates(x, y, this.svg_, false);
+  this.blockSpace.getDragCanvas().setAttribute('transform', 'translate(' + offset.x + ',' + offset.y + ')');
 };
 
 /**
@@ -934,9 +936,11 @@ Blockly.BlockSpaceEditor.prototype.setBlockSpaceMetricsNoScroll_ = function() {
     var translation = 'translate(' + (metrics.absoluteLeft) + ',' +
       (metrics.absoluteTop) + ')';
     this.blockSpace.getCanvas().setAttribute('transform', translation);
-    this.blockSpace.getDragCanvas().setAttribute('transform', translation);
     this.blockSpace.getBubbleCanvas().setAttribute('transform',
       translation);
+
+    var offset = Blockly.convertCoordinates(metrics.absoluteLeft, metrics.absoluteTop, this.svg_, false);
+    this.blockSpace.getDragCanvas().setAttribute('transform', 'translate(' + offset.x + ',' + offset.y + ')');
   }
 };
 

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -249,9 +249,6 @@ Blockly.Flyout.prototype.setMetrics_ = function(yRatio) {
   var y = this.blockSpace_.yOffsetFromView + metrics.absoluteTop;
   this.blockSpace_.getCanvas().setAttribute('transform', 'translate(0,'
       + y + ')');
-
-  var offset = Blockly.convertCoordinates(0, y, Blockly.topMostSVGParent(this.svgGroup_), false);
-  this.blockSpace_.getDragCanvas().setAttribute('transform', 'translate(' + offset.x + ',' + offset.y + ')');
 };
 
 /**

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -249,8 +249,9 @@ Blockly.Flyout.prototype.setMetrics_ = function(yRatio) {
   var y = this.blockSpace_.yOffsetFromView + metrics.absoluteTop;
   this.blockSpace_.getCanvas().setAttribute('transform', 'translate(0,'
       + y + ')');
-  this.blockSpace_.getDragCanvas().setAttribute('transform',
-      'translate(0,' + y + ')');
+
+  var offset = Blockly.convertCoordinates(0, y, Blockly.topMostSVGParent(this.svgGroup_), false);
+  this.blockSpace_.getDragCanvas().setAttribute('transform', 'translate(' + offset.x + ',' + offset.y + ')');
 };
 
 /**

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -168,6 +168,7 @@ Blockly.Flyout.prototype.dispose = function() {
     Blockly.unbindEvent_(this.changeWrapper_);
     this.changeWrapper_ = null;
   }
+  this.blockSpace_.dispose();
   this.blockSpace_ = null;
   if (this.svgGroup_) {
     goog.dom.removeNode(this.svgGroup_);

--- a/core/ui/bubble.js
+++ b/core/ui/bubble.js
@@ -42,7 +42,7 @@ goog.require('Blockly.BlockSpace');
  */
 Blockly.Bubble = function(blockSpace, content, shape,
                           anchorX, anchorY,
-                          bubbleWidth, bubbleHeight) {
+                          bubbleWidth, bubbleHeight, dragCanvas) {
   var angle = Blockly.Bubble.ARROW_ANGLE;
   if (Blockly.RTL) {
     angle = -angle;
@@ -52,6 +52,7 @@ Blockly.Bubble = function(blockSpace, content, shape,
   this.blockSpace_ = blockSpace;
   this.content_ = content;
   this.shape_ = shape;
+  this.dragCanvas_ = dragCanvas;
   var canvas = blockSpace.getBubbleCanvas();
   canvas.appendChild(this.createDom_(content, !!(bubbleWidth && bubbleHeight)));
 
@@ -443,6 +444,9 @@ Blockly.Bubble.prototype.positionBubble_ = function() {
   var top = this.relativeTop_ + this.anchorY_;
   this.bubbleGroup_.setAttribute('transform',
       'translate(' + left + ', ' + top + ')');
+
+  var offset = Blockly.convertCoordinates(Blockly.RTL ? this.blockSpaceWidth_ : 0, 0, this.content_, false);
+  this.dragCanvas_.setAttribute('transform', 'translate(' + offset.x + ',' + offset.y + ')');
 };
 
 /**

--- a/core/ui/mutator.js
+++ b/core/ui/mutator.js
@@ -148,8 +148,10 @@ Blockly.Mutator.prototype.resizeBubble_ = function() {
     // Scroll the blockSpace to always left-align.
     var translation = 'translate(' + this.blockSpaceWidth_ + ',0)';
     this.blockSpace_.getCanvas().setAttribute('transform', translation);
-    this.blockSpace_.getDragCanvas().setAttribute('transform', translation);
   }
+
+  var offset = Blockly.convertCoordinates(Blockly.RTL ? this.blockSpaceWidth_ : 0, 0, this.svgDialog_, false);
+  this.blockSpace_.getDragCanvas().setAttribute('transform', 'translate(' + offset.x + ',' + offset.y + ')');
 };
 
 /**
@@ -162,10 +164,11 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
     return;
   }
   if (visible) {
+    this.createEditor_();
     // Create the bubble.
     this.bubble_ = new Blockly.Bubble(this.block_.blockSpace,
-        this.createEditor_(), this.block_.svg_.svgGroup_,
-        this.iconX_, this.iconY_, null, null);
+        this.svgDialog_, this.block_.svg_.svgGroup_,
+        this.iconX_, this.iconY_, null, null, this.blockSpace_.getDragCanvas());
     var thisObj = this;
     this.blockSpace_.flyout_.init(this.blockSpace_, false);
     this.blockSpace_.flyout_.show(this.quarkXml_);


### PR DESCRIPTION
Allow blocks to be dragged outside the extents of their block space SVG.  Also ensures that the block is always at the top of the z-index while dragging.