### PR TITLE
Build source maps for blockly_compressed.js

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -38,6 +38,8 @@ else
   --entry_point Blockly \
   --js core/ node_modules/google-closure-library/closure/ \
   --only_closure_dependencies \
+  --source_map_include_content \
+  --create_source_map build-output/blockly_compressed.js.map \
   >> build-output/blockly_compressed.js
 
   echo -e '// Do not edit this generated file\n"use strict";\n' > build-output/javascript_compressed.js

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "phantomjs-prebuilt": "^2.1.3",
-    "google-closure-compiler": "^20160911.0.0",
+    "google-closure-compiler": "^20170218.0.0",
     "google-closure-library": "^20160911.0.0"
   }
 }


### PR DESCRIPTION
Allows easier debugging on New Relic.  Without source maps:

![source-maps-before](https://cloud.githubusercontent.com/assets/413693/24670298/592febd0-1922-11e7-9831-c33e58749cfb.png)

After adding the source map:

![source-maps-after](https://cloud.githubusercontent.com/assets/413693/24670308/633f6650-1922-11e7-8534-d84a489a9c40.png)