### PR TITLE
Speculative fix for `this.sourceBlock_ is null`

### DIFF
--- a/core/ui/fields/field_dropdown.js
+++ b/core/ui/fields/field_dropdown.js
@@ -146,6 +146,9 @@ Blockly.FieldDropdown.prototype.showEditor_ = function(container) {
  * @override
  */
 Blockly.FieldDropdown.prototype.positionWidgetDiv = function() {
+  if (!this.sourceBlock_) {
+    return;
+  }
   var windowSize = goog.dom.getViewportSize();
   var scrollOffset = goog.style.getViewportPageOffset(document);
   var xy = Blockly.getAbsoluteXY_(/** @type {!Element} */ (this.borderRect_), this.getRootSVGElement_());


### PR DESCRIPTION
I spent a few days trying to track down a repro for this New Relic error without any luck.  Blockly somehow gets into a bad state where a `FieldDropdown` no longer has a reference to it's `sourceBlock_`.  Later, [drag is terminated for the selected block](https://github.com/code-dot-org/blockly/blob/828d2b04e54e4d30953d6b8ae3160d6b61bad588/core/ui/block.js#L355) which triggers a `BLOCK_SPACE_SCROLLED` event.  This [triggers a call to `positionWidgetDiv`](https://github.com/code-dot-org/blockly/blob/0fe9723fc49be45206c09415985182b14072b28b/core/ui/fields/field_colour.js#L138) which throws when `getRootSVGElement_` attempts to access the source block's block space.

Without a repro I don't have high confidence that this defensive fix will address the actual issue, but I think it's worth a try.  By gracefully handling the case where the field has already been disposed, we allow the drag to terminate normally (instead of throwing).  Hopefully this leave the block space in a good state so there is no longer a user-visible issue.

![screen shot 2017-04-04 at 1 59 09 pm](https://cloud.githubusercontent.com/assets/413693/24681855/cc2156dc-194b-11e7-9b9d-c0c4b915468d.png)

Example Zendesk tickets:

https://codeorg.zendesk.com/agent/tickets/82183
https://codeorg.zendesk.com/agent/tickets/85114
https://codeorg.zendesk.com/agent/tickets/86855
https://codeorg.zendesk.com/agent/tickets/91353