### PR TITLE
Firefox returns null for getScreenCTM if svg is hidden or has 0 height

### DIFF
--- a/core/utils/utils.js
+++ b/core/utils/utils.js
@@ -379,6 +379,11 @@ Blockly.convertCoordinates = function(x, y, svg, toSvg) {
   svgPoint.x = x;
   svgPoint.y = y;
   var matrix = svg.getScreenCTM();
+  if (!matrix) {
+    // Firefox returns null for getScreenCTM if svg is hidden or has 0 height.
+    var clientRect = svg.getBoundingClientRect();
+    matrix = svg.createSVGMatrix(clientRect.left, clientRect.top);
+  }
   if (toSvg) {
     matrix = matrix.inverse();
   }


### PR DESCRIPTION
Fixes an exception in Firefox when creating feedback block space with zero height.

![null-transform-matrix](https://cloud.githubusercontent.com/assets/413693/24820177/9ee75902-1b9c-11e7-9ddd-42d8e3fefdcb.png)

Stack trace:
```
TypeError: Argument 1 of SVGPoint.matrixTransform is not an object.
Blockly.convertCoordinates()
blockly.js:29563
Blockly.BlockSpaceEditor.prototype.setBlockSpaceMetricsNoScroll_()
blockly.js:25367
Blockly.BlockSpaceEditor.prototype.svgResize()
blockly.js:25176
Blockly.BlockSpaceEditor.prototype.createDom_()
blockly.js:25003
Blockly.BlockSpaceEditor()
blockly.js:24931
Blockly.BlockSpace.createReadOnlyBlockSpace()
blockly.js:6808
[979]/FeedbackBlocks.prototype.render()
code-studio-common.js:32881
[1243]/FeedbackUtils.prototype.displayFeedback()
code-studio-common.js:46795
[154]/StudioApp.prototype.displayFeedback()
code-studio-common.js:8147
displayFeedback()
maze.js:5729
[2415]/Maze.scheduleAnimations/finishAnimations/<()
maze.js:6048
blockly.js:29563:12
```