### PR TITLE
Unselecting a block should always terminate drag

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -399,6 +399,7 @@ Blockly.Block.prototype.unselect = function() {
   if (!this.svg_) {
     throw 'Block is not rendered.';
   }
+  Blockly.BlockSpaceEditor.terminateDrag_();
   Blockly.selected = null;
   this.svg_.removeSelect();
   this.svg_.removeSpotlight();


### PR DESCRIPTION
Fixes multiple touch points bug on iOS while dragging a block.

Repro on iOS:
 - Start dragging a block.
 - Use a second finger to start panning the page.
 - Release when neither finger is touching the dragged block.

https://rpm.newrelic.com/accounts/501463/browser/3787364/js_errors#id=497715591