### PR TITLE
New speculative fix for `this.sourceBlock_ is null` on all field types

### DIFF
--- a/core/ui/fields/field.js
+++ b/core/ui/fields/field.js
@@ -379,6 +379,12 @@ Blockly.Field.prototype.positionWidgetDiv = function() {
   // intentional noop; overridden by child classes
 };
 
+Blockly.Field.prototype.handleBlockSpaceScrolled = function () {
+  if (this.sourceBlock_) {
+    this.positionWidgetDiv();
+  }
+};
+
 Blockly.Field.prototype.showWidgetDiv_ = function() {
   Blockly.WidgetDiv.show(this, this.generateWidgetDisposeHandler_());
 
@@ -392,7 +398,7 @@ Blockly.Field.prototype.showWidgetDiv_ = function() {
     if (!this.blockSpaceScrolledListenKey_) {
       this.blockSpaceScrolledListenKey_ = events.listen(
           Blockly.BlockSpace.EVENTS.BLOCK_SPACE_SCROLLED,
-          this.positionWidgetDiv.bind(this));
+          this.handleBlockSpaceScrolled.bind(this));
     }
   }
 };

--- a/core/ui/fields/field_dropdown.js
+++ b/core/ui/fields/field_dropdown.js
@@ -146,9 +146,6 @@ Blockly.FieldDropdown.prototype.showEditor_ = function(container) {
  * @override
  */
 Blockly.FieldDropdown.prototype.positionWidgetDiv = function() {
-  if (!this.sourceBlock_) {
-    return;
-  }
   var windowSize = goog.dom.getViewportSize();
   var scrollOffset = goog.style.getViewportPageOffset(document);
   var xy = Blockly.getAbsoluteXY_(/** @type {!Element} */ (this.borderRect_), this.getRootSVGElement_());


### PR DESCRIPTION
PR https://github.com/code-dot-org/blockly/pull/38 indeed got rid of the `Blockly.FieldDropdown` error, however we started seeing new errors for `Blockly.FieldTextInput`.  Rather than add the null check for each field check, instead add it to the scroll listener before `this.positionWidgetDiv()` is called.