### PR TITLE
[WIP] fix 'Cannot read property 'updateScrollableSize' of null' error

### DIFF
--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -364,8 +364,8 @@ Blockly.Flyout.prototype.hide = function(opt_saveBlock) {
   }
   // Delete all the blocks.
   this.blockSpace_.getTopBlocks(false).forEach(function (block) {
-    if (block !== opt_saveBlock) {
-      block.dispose(false, false, true);
+    if (block.rendered && block !== opt_saveBlock) {
+      block.dispose(false, false);
     }
   });
   // Delete all the background buttons.

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -365,7 +365,7 @@ Blockly.Flyout.prototype.hide = function(opt_saveBlock) {
   // Delete all the blocks.
   this.blockSpace_.getTopBlocks(false).forEach(function (block) {
     if (block !== opt_saveBlock) {
-      block.dispose(false, false);
+      block.dispose(false, false, true);
     }
   });
   // Delete all the background buttons.


### PR DESCRIPTION
We've had a lingering NewRelic error; TypeError: Cannot read property 'updateScrollableSize' of null

Repros on https://studio.code.org/s/20-hour/stage/13/puzzle/10
1. Drag a new “do something” function into the workspace
2. Click on the “Functions” category, then click anywhere else

https://rpm.newrelic.com/accounts/501463/browser/3787364/js_errors#id=-1241966532&tab_index=1&instance_index=1

The problem here is that when we drag the "do something" function into the workspace, the flyout gets populated with a `procedures_callnoreturn` block for the function definition; but when we call dispose on that function it [also disposes the call](https://github.com/code-dot-org/blockly/blob/staging/blocks/procedures.js#L171-L179). However since the call is in the blockSpace, the blockSpace is _also_ trying to dispose of the block, causing problems.

There are several potential solutions here; one is to let the definition keep disposing of its own call, and teach the flyout how to just ignore blocks that have already been deleted. Another is the one recorded here, which is where we tell the definition to leave its call well enough alone so we can take care of it ourselves.

This PR is a WIP while I figure out which solution I like best.