### PR TITLE
Add disable autopopulate option

### DIFF
--- a/core/initialization/inject.js
+++ b/core/initialization/inject.js
@@ -159,6 +159,7 @@ Blockly.parseOptions_ = function(options) {
     disableIfElseEditing: options['disableIfElseEditing'] || false,
     disableParamEditing: options['disableParamEditing'] || false,
     disableVariableEditing: options['disableVariableEditing'] || false,
+    disableProcedureAutopopulate: options['disableProcedureAutopopulate'] || false,
     useModalFunctionEditor: options['useModalFunctionEditor'] || false,
     useContractEditor: options['useContractEditor'] || false,
     disableExamples: options['disableExamples'] || false,

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -392,6 +392,27 @@ Blockly.Flyout.prototype.layoutBlock_ = function(block, cursor, gap, initialX) {
 };
 
 /**
+ * Convert the given XML to Blocks and populate the given arrays of blocks and
+ * gaps appropriately.
+ *
+ * @see Blockly.Flyout.prototype.show
+ *
+ * @param {!Array|string} xmlList List of blocks (as XML) to lay out
+ * @param {!Array|Block} blocks Array to which the newly-created blocks are
+ *     appended
+ * @param {!Array|number} gaps Array to which the gap values for the
+ *     newly-created blocks are appended
+ */
+Blockly.Flyout.prototype.layoutXmlToBlocks_ = function(xmlList, blocks, gaps, margin) {
+  for (var i = 0, xml; xml = xmlList[i]; i++) {
+    if (xml.tagName && xml.tagName.toUpperCase() === 'BLOCK') {
+      blocks.push(Blockly.Xml.domToBlock(this.blockSpace_, xml));
+      gaps.push(margin * 3);
+    }
+  }
+};
+
+/**
  * Show and populate the flyout.
  * @param {!Array|string} xmlList List of blocks to show.
  *     Variables and procedures have a custom set of blocks.
@@ -422,12 +443,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
     // Special category for variables.
     // Allow for a mix of static + dynamic blocks. Static blocks will appear
     // first in the category
-    for (var i = 1, xml; xml = xmlList[i]; i++) {
-      if (xml.tagName && xml.tagName.toUpperCase() === 'BLOCK') {
-        blocks.push(Blockly.Xml.domToBlock(this.blockSpace_, xml));
-        gaps.push(margin * 3);
-      }
-    }
+    this.layoutXmlToBlocks_(xmlList.slice(1), blocks, gaps, margin);
     Blockly.Variables.flyoutCategory(blocks, gaps, margin, this.blockSpace_);
   } else if (firstBlock === Blockly.Procedures.NAME_TYPE) {
     // Special category for procedures.
@@ -449,12 +465,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
       function(procedureInfo) { return procedureInfo.isFunctionalVariable; }
     );
   } else {
-    for (var i = 0, xml; xml = xmlList[i]; i++) {
-      if (xml.tagName && xml.tagName.toUpperCase() === 'BLOCK') {
-        blocks.push(Blockly.Xml.domToBlock(this.blockSpace_, xml));
-        gaps.push(margin * 3);
-      }
-    }
+    this.layoutXmlToBlocks_(xmlList, blocks, gaps, margin);
   }
 
   // Lay out the blocks vertically.

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -450,6 +450,11 @@ Blockly.Flyout.prototype.show = function(xmlList) {
     if (Blockly.functionEditor && !Blockly.functionEditor.isOpen()) {
       this.addButtonToFlyout_(cursor, Blockly.Msg.FUNCTION_CREATE, this.createFunction_);
     }
+
+    if (Blockly.disableProcedureAutopopulate) {
+      this.layoutXmlToBlocks_(xmlList.slice(1), blocks, gaps, margin);
+    }
+
     Blockly.Procedures.flyoutCategory(blocks, gaps, margin,
       this.blockSpace_,
       function(procedureInfo) { return !procedureInfo.isFunctionalVariable; }

--- a/core/utils/procedures.js
+++ b/core/utils/procedures.js
@@ -184,7 +184,7 @@ Blockly.Procedures.rename = function(text) {
  *  will be included in the category.
  */
 Blockly.Procedures.flyoutCategory = function(blocks, gaps, margin, blockSpace, opt_procedureInfoFilter) {
-  if (!Blockly.functionEditor) {
+  if (!Blockly.functionEditor && !Blockly.disableProcedureAutopopulate) {
     if (Blockly.Blocks.procedures_defnoreturn) {
       var block = new Blockly.Block(blockSpace, 'procedures_defnoreturn');
       block.initSvg();


### PR DESCRIPTION
As it currently stands, Blockly works some magic with Function categories. Specifically, when it detects that a category is supposed to be a Function category, it ignores any levelbuilder-specified XML for that category and instead populates it with three different function definition blocks; `noreturn`, `return`, and `ifreturn`. It also populates it with call blocks for any functions that have already been defined.

Unfortunately, there are situations in which we want to present students with a subset of those definition blocks (mostly situations in which we have not yet introduced the concept of returns and would like to only expose `noreturn`). We therefore would like a new Blockly option for disabling the autopopulation of function definitions and instead actually relying on the levelbuilder-specified XML.