### PR TITLE
add IE-specific logic for positioning the Block Limit indicator

### DIFF
--- a/core/ui/block_svg/block_svg.js
+++ b/core/ui/block_svg/block_svg.js
@@ -563,6 +563,14 @@ Blockly.BlockSvg.prototype.updateLimit = function (limit) {
   var rectWidth = Math.max(textWidth + HALF_BUBBLE_SIZE, BUBBLE_SIZE);
   this.limitRect_.setAttribute('width', rectWidth);
   this.limitText_.setAttribute('x', Math.round(rectWidth * 0.5) - HALF_BUBBLE_SIZE);
+
+  // IE Does not support dominant-baseline, so we can't actually vertically
+  // center the text. Instead simply shift it down by one quarter the height of
+  // the bubble, which should be visually quite close if not necessarily exact
+  if (Blockly.isMsie() || Blockly.isTrident()) {
+    this.limitText_.setAttribute('y', BUBBLE_SIZE / 4);
+  }
+
 };
 
 /**


### PR DESCRIPTION
Before

![image](https://user-images.githubusercontent.com/244100/28485998-a5dc2402-6e32-11e7-9098-07d327315223.png)

After

![image](https://user-images.githubusercontent.com/244100/28485974-6f5160fa-6e32-11e7-8cc6-65f6c607f140.png)
