### PR TITLE
Add angle helper to value inputs

### DIFF
--- a/core/ui/fields/field_angle_textinput.js
+++ b/core/ui/fields/field_angle_textinput.js
@@ -1,70 +1,35 @@
 /**
- * @fileoverview Text input field.
- * @author fraser@google.com (Neil Fraser)
+ * @fileoverview special Text Input field that always shows angle helper
+ * @author elijah@code.org (Elijah Hamovitz)
  */
 'use strict';
 
 goog.provide('Blockly.FieldAngleTextInput');
-goog.require('Blockly.FieldTextInput');
+
 goog.require('Blockly.AngleHelper');
+goog.require('Blockly.BlockFieldHelper');
+goog.require('Blockly.FieldTextInput');
 
 /**
- * Class for an editable text field.
+ * Class for an editable text field which will always show the Angle HElper
+ * @param {string} directionTitle the title of the field from which to obtain
+ *        direction information
  * @param {string} text The initial content of the field.
- * @param {Function} opt_changeHandler An optional function that is called
- *     to validate any constraints on what the user entered.  Takes the new
- *     text as an argument and returns the accepted text or null to abort
- *     the change.
- * @extends {Blockly.Field}
+ * @extends {Blockly.FieldTextInput}
  * @constructor
  */
-Blockly.FieldAngleTextInput = function(directionTitleName, text) {
-  this.angleHelper = null;
-  this.directionTitleName = directionTitleName;
+Blockly.FieldAngleTextInput = function(directionTitle, text) {
+  this.directionTitle = directionTitle;
   Blockly.FieldAngleTextInput.superClass_.constructor.call(this,
       text, Blockly.FieldTextInput.numberValidator);
 };
 goog.inherits(Blockly.FieldAngleTextInput, Blockly.FieldTextInput);
 
-Blockly.FieldAngleTextInput.SIZE = 150;
-
-Blockly.FieldAngleTextInput.prototype.dispose = function() {
-  if (this.angleHelper) {
-    this.angleHelper.dispose();
+Blockly.FieldAngleTextInput.prototype.getFieldHelperOptions_ = function(field_helper) {
+  if (field_helper === Blockly.BlockFieldHelper.ANGLE_HELPER) {
+      return {
+        directionTitle: this.directionTitle,
+        block: this.sourceBlock_
+      }
   }
-  Blockly.FieldAngleTextInput.superClass_.dispose.call(this);
-};
-
-/**
- * Show the inline free-text editor on top of the text.
- * @private
- */
-Blockly.FieldAngleTextInput.prototype.showEditor_ = function() {
-  Blockly.FieldAngleTextInput.superClass_.showEditor_.call(this);
-  var div = Blockly.WidgetDiv.DIV;
-
-  var container = goog.dom.createDom('div', 'blocklyFieldAngleTextInput');
-  container.style.height = Blockly.FieldAngleTextInput.SIZE + 'px';
-  container.style.width = Blockly.FieldAngleTextInput.SIZE + 'px';
-  div.appendChild(container);
-
-  var dir = this.sourceBlock_.getTitleValue(this.directionTitleName);
-  this.angleHelper = new Blockly.AngleHelper(dir, {
-    onUpdate: function () {
-      var value = this.angleHelper.getAngle().toString();
-      this.setText(value);
-      Blockly.FieldTextInput.htmlInput_.value = value;
-    }.bind(this),
-    arcColour: this.sourceBlock_.getHexColour(),
-    height: Blockly.FieldAngleTextInput.SIZE,
-    width: Blockly.FieldAngleTextInput.SIZE,
-    angle: parseInt(this.getValue())
-  });
-
-  this.angleHelper.init(container);
-};
-
-Blockly.FieldAngleTextInput.prototype.onHtmlInputChange_ = function(e) {
-  Blockly.FieldAngleTextInput.superClass_.onHtmlInputChange_.call(this, e);
-  this.angleHelper.animateAngleChange(parseInt(this.getText()));
 };

--- a/core/ui/fields/field_angle_textinput.js
+++ b/core/ui/fields/field_angle_textinput.js
@@ -11,7 +11,7 @@ goog.require('Blockly.BlockFieldHelper');
 goog.require('Blockly.FieldTextInput');
 
 /**
- * Class for an editable text field which will always show the Angle HElper
+ * Class for an editable text field which will always show the Angle Helper
  * @param {string} directionTitle the title of the field from which to obtain
  *        direction information
  * @param {string} text The initial content of the field.

--- a/tests/test_dependency_map.js
+++ b/tests/test_dependency_map.js
@@ -52,11 +52,11 @@ goog.addDependency('../../../../core/ui/contract_editor/svg_text_button.js', ['B
 goog.addDependency('../../../../core/ui/contract_editor/type_dropdown.js', ['Blockly.TypeDropdown'], [], false);
 goog.addDependency('../../../../core/ui/contract_editor/x_button.js', ['Blockly.XButton'], [], false);
 goog.addDependency('../../../../core/ui/css.js', ['Blockly.Css'], ['goog.cssom'], false);
-goog.addDependency('../../../../core/ui/fields/angle_helper.js', ['Blockly.AngleHelper'], [], false);
+goog.addDependency('../../../../core/ui/fields/angle_helper.js', ['Blockly.AngleHelper'], ['goog.math.Vec2'], false);
 goog.addDependency('../../../../core/ui/fields/field.js', ['Blockly.Field'], ['Blockly.BlockSvg'], false);
 goog.addDependency('../../../../core/ui/fields/field_angle.js', ['Blockly.FieldAngle'], ['Blockly.FieldTextInput'], false);
 goog.addDependency('../../../../core/ui/fields/field_angle_dropdown.js', ['Blockly.FieldAngleDropdown'], ['Blockly.AngleHelper', 'Blockly.FieldDropdown'], false);
-goog.addDependency('../../../../core/ui/fields/field_angle_textinput.js', ['Blockly.FieldAngleTextInput'], ['Blockly.AngleHelper', 'Blockly.FieldAngleTextInput'], false);
+goog.addDependency('../../../../core/ui/fields/field_angle_textinput.js', ['Blockly.FieldAngleTextInput'], ['Blockly.AngleHelper', 'Blockly.FieldTextInput'], false);
 goog.addDependency('../../../../core/ui/fields/field_checkbox.js', ['Blockly.FieldCheckbox'], ['Blockly.Field'], false);
 goog.addDependency('../../../../core/ui/fields/field_colour.js', ['Blockly.FieldColour'], ['Blockly.Field', 'goog.ui.ColorPicker'], false);
 goog.addDependency('../../../../core/ui/fields/field_colour_dropdown.js', ['Blockly.FieldColourDropdown'], ['Blockly.Field', 'Blockly.FieldRectangularDropdown'], false);
@@ -67,7 +67,7 @@ goog.addDependency('../../../../core/ui/fields/field_image_dropdown.js', ['Block
 goog.addDependency('../../../../core/ui/fields/field_label.js', ['Blockly.FieldLabel'], ['Blockly.Field', 'Blockly.Tooltip'], false);
 goog.addDependency('../../../../core/ui/fields/field_parameter.js', ['Blockly.FieldParameter'], ['Blockly.FieldVariable'], false);
 goog.addDependency('../../../../core/ui/fields/field_rectangular_dropdown.js', ['Blockly.FieldRectangularDropdown'], ['Blockly.Field', 'Blockly.FieldImage', 'Blockly.ImageDimensionCache'], false);
-goog.addDependency('../../../../core/ui/fields/field_textinput.js', ['Blockly.FieldTextInput'], ['Blockly.Field', 'Blockly.Msg', 'goog.asserts', 'goog.userAgent'], false);
+goog.addDependency('../../../../core/ui/fields/field_textinput.js', ['Blockly.FieldTextInput'], ['Blockly.AngleHelper', 'Blockly.BlockFieldHelper', 'Blockly.Field', 'Blockly.Msg', 'goog.asserts', 'goog.userAgent'], false);
 goog.addDependency('../../../../core/ui/fields/field_variable.js', ['Blockly.FieldVariable'], ['Blockly.FieldDropdown', 'Blockly.Msg', 'Blockly.Variables'], false);
 goog.addDependency('../../../../core/ui/function_editor.js', ['Blockly.FunctionEditor'], ['Blockly.BlockSpace', 'Blockly.BlockSpaceEditor', 'Blockly.HorizontalFlyout', 'goog.array', 'goog.dom', 'goog.events', 'goog.structs.LinkedMap', 'goog.style'], false);
 goog.addDependency('../../../../core/ui/icon.js', ['Blockly.Icon'], [], false);
@@ -76,6 +76,7 @@ goog.addDependency('../../../../core/ui/mutator.js', ['Blockly.Mutator'], ['Bloc
 goog.addDependency('../../../../core/ui/tooltip.js', ['Blockly.Tooltip'], [], false);
 goog.addDependency('../../../../core/ui/warning.js', ['Blockly.Warning'], ['Blockly.Bubble', 'Blockly.Icon'], false);
 goog.addDependency('../../../../core/ui/widgetdiv.js', ['Blockly.WidgetDiv'], ['Blockly.Css', 'goog.dom'], false);
+goog.addDependency('../../../../core/utils/block_field_helper.js', ['Blockly.BlockFieldHelper'], [], false);
 goog.addDependency('../../../../core/utils/block_value_type.js', ['Blockly.BlockValueType'], [], false);
 goog.addDependency('../../../../core/utils/functional_block_utils.js', ['Blockly.FunctionalBlockUtils', 'Blockly.FunctionalTypeColors'], ['Blockly.BlockValueType'], false);
 goog.addDependency('../../../../core/utils/image_dimension_cache.js', ['Blockly.ImageDimensionCache'], [], false);


### PR DESCRIPTION
Teach the existing FieldTextInput ow to leverage the new Field Helpers to display an Angle Helper when enabled.

This mostly involves moving a bunch of functionality from the child class FieldAngleTextInput into its parent; the child is now simply a version of FieldTextInput for which the angle helper is always enabled, rather than conditionally.