### PR TITLE
add 'field helper' concept to connections

### DIFF
--- a/core/connections/connection.js
+++ b/core/connections/connection.js
@@ -85,6 +85,12 @@ Blockly.Connection = function(source, type) {
    * @private
    */
   this.check_ = null;
+
+  /**
+   * Enabled field helpers for this connection and their associated options
+   * @private
+   */
+  this.fieldHelpers_ = {};
 };
 
 /**
@@ -676,6 +682,30 @@ Blockly.Connection.prototype.setCheck = function(check) {
   }
   return this;
 };
+
+/**
+ * Enable the specified field helper with the specified options for this
+ * connection
+ * @param {string} fieldHelper the field helper to retrieve. One of
+ *        Blockly.BlockFieldHelper
+ * @param {*} options for this helper
+ * @return {!Blockly.Connection} The connection being modified
+ *     (to allow chaining).
+ */
+Blockly.Connection.prototype.addFieldHelper = function (fieldHelper, options) {
+  this.fieldHelpers_[fieldHelper] = options;
+
+  return this;
+}
+
+/**
+ * Retrieve the options for the specified field helper if it has been enabled
+ * @param {string} fieldHelper the field helper to retrieve. One of
+ *        Blockly.BlockFieldHelper
+ */
+Blockly.Connection.prototype.getFieldHelperOptions = function (fieldHelper) {
+  return this.fieldHelpers_ && this.fieldHelpers_[fieldHelper];
+}
 
 /**
  * @returns {?Array.<Blockly.BlockValueType>}

--- a/core/ui/fields/field.js
+++ b/core/ui/fields/field.js
@@ -55,6 +55,23 @@ Blockly.Field = function(text) {
 };
 
 /**
+ * If this field is attached to a block whose output connection is attached to a
+ * connection that has the specified field helper, get the options for that
+ * field helper.
+ * @param {string} fieldHelper - the field helper to retrieve. One of
+ *        Blockly.BlockFieldHelper
+ * @return {Object|undefined} the options object if it exists
+ */
+Blockly.Field.prototype.getFieldHelperOptions_ = function(fieldHelper) {
+  return (
+    this.sourceBlock_ &&
+    this.sourceBlock_.outputConnection &&
+    this.sourceBlock_.outputConnection.targetConnection &&
+    this.sourceBlock_.outputConnection.targetConnection.getFieldHelperOptions(fieldHelper)
+  );
+};
+
+/**
  * @returns {Blockly.BlockSpace.blockSpaceEditor}
  * @protected
  */

--- a/core/ui/input.js
+++ b/core/ui/input.js
@@ -160,6 +160,23 @@ Blockly.Input.prototype.setCheck = function(check) {
 };
 
 /**
+ * Enable the specified field helper with the specified options for this
+ * input's connection
+ * @param {string} fieldHelper the field helper to retrieve. One of
+ *        Blockly.BlockFieldHelper
+ * @param {*} options for this helper
+ * @return {!Blockly.Input} The input being modified (to allow chaining).
+ */
+Blockly.Input.prototype.addFieldHelper = function(fieldHelper, options) {
+  if (this.type !== Blockly.INPUT_VALUE) {
+    throw 'Only Value Inputs can be augmented with helpers';
+  }
+
+  this.connection.addFieldHelper(fieldHelper, options);
+  return this;
+};
+
+/**
  * Change the alignment of the connection's title(s).
  * @param {number} align One of Blockly.ALIGN_LEFT, ALIGN_CENTRE, ALIGN_RIGHT.
  *   In RTL mode directions are reversed, and ALIGN_RIGHT aligns to the left.

--- a/core/utils/block_field_helper.js
+++ b/core/utils/block_field_helper.js
@@ -1,0 +1,11 @@
+'use strict';
+
+goog.provide('Blockly.BlockFieldHelper');
+
+/**
+ * @enum {string}
+ */
+Blockly.BlockFieldHelper = {
+  ANGLE_HELPER: 'Angle Helper'
+};
+


### PR DESCRIPTION
The concept here is that we want to be able to add the ability for certain inputs/connections to augment the fields being attached to them with certain helpers. Specifically, we want for Artist blocks with value inputs like this one

![image](https://user-images.githubusercontent.com/244100/29690894-b81d7e84-88dd-11e7-80fe-049ea5ee69e2.png)

To still be able to show the Angle Helper:

![image](https://user-images.githubusercontent.com/244100/29690900-c38457ca-88dd-11e7-9f9c-1da68b5c853b.png)

This PR proposes a generic system to do that. When we define the inputs for the block, in addition to validation checks we can add a Field Helper like so:

```
  blockly.Blocks.draw_turn = {
    // Block for turning left or right.
    helpUrl: '',
    init: function () {
      this.setHSV(184, 1.00, 0.74);
      this.appendValueInput('VALUE')
        .setCheck(blockly.BlockValueType.NUMBER)
        .addFieldHelper(blockly.BlockFieldHelper.ANGLE_HELPER, {
          block: this,
          directionTitle: 'DIR',
        })
  ...
```

And then Fields can consult `getFieldHelperOptions_ ` from within `showEditor_ ` to see if they are (at the time of editing) in a connection hierarchy that wants them to show a helper, meaning we can dynamically display the angle helper based not on the field itself, but based on the input it's connected to!

![ah](https://user-images.githubusercontent.com/244100/29691578-76d32d68-88e0-11e7-914e-c1d28580ad5e.gif)

I'd love to get y'all's general thoughts on this approach.