### PR TITLE
Expose block "canDisconnectFromParent" property

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -971,6 +971,19 @@ Blockly.Block.prototype.showContextMenu_ = function(e) {
     };
     options.push(editableOption);
 
+    // can disconnect from parent
+    var canDisconnectFromParentOption = {
+      text: this.canDisconnectFromParent_ ?
+          "Lock to Parent Block" : "Unlock from Parent Block",
+      enabled: true,
+      callback: function () {
+        block.setCanDisconnectFromParent(!block.canDisconnectFromParent_);
+        Blockly.ContextMenu.hide();
+      }
+    };
+    options.push(canDisconnectFromParentOption);
+
+
     // limit
     var getCurrentLimit = function() {
       return block.blockSpace.blockSpaceEditor.blockLimits.getLimit(block.type);

--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -88,7 +88,6 @@ Blockly.Block = function(blockSpace, prototypeName, htmlId) {
 
   /**
    * Whether this block is allowed to disconnect from its parent block.
-   * This property does not get serialized/deserialized.
    * @private {boolean}
    */
   this.canDisconnectFromParent_ = true;

--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -154,6 +154,9 @@ Blockly.Xml.blockToDom = function(block, ignoreChildBlocks) {
   if (block.isNextConnectionDisabled()) {
     element.setAttribute('next_connection_disabled', true);
   }
+  if (!block.canDisconnectFromParent()) {
+    element.setAttribute('can_disconnect_from_parent', false);
+  }
   if (block.isFunctionDefinition() && block.userCreated) {
     element.setAttribute('usercreated', true);
   }
@@ -363,6 +366,10 @@ Blockly.Xml.domToBlock = function(blockSpace, xmlBlock) {
   var next_connection_disabled = xmlBlock.getAttribute('next_connection_disabled');
   if (next_connection_disabled) {
     block.setNextConnectionDisabled(next_connection_disabled === 'true');
+  }
+  var can_disconnect_from_parent = xmlBlock.getAttribute('can_disconnect_from_parent');
+  if (can_disconnect_from_parent) {
+    block.setCanDisconnectFromParent(can_disconnect_from_parent === 'true');
   }
   var userVisible = xmlBlock.getAttribute('uservisible');
   if (userVisible) {


### PR DESCRIPTION
An already-existing property that was formerly just used for example blocks in the contract editor, we can now in the right-click menu lock a block to its parent, preventing the user from separating them (or from adding new blocks in between).

This can, among other things, be used to create user-visible function definitions that are movable but otherwise unchangeable by the user.

![lock](https://user-images.githubusercontent.com/244100/31412402-cf7774e8-adc9-11e7-8012-e9b8ef11ff8f.gif)
