### PR TITLE
Don't bind dom events on temporary blockspaces

### DIFF
--- a/build-output/blockly_uncompressed.js
+++ b/build-output/blockly_uncompressed.js
@@ -6820,7 +6820,7 @@ Blockly.BlockSpace.createReadOnlyBlockSpace = function(container, xml, opt_optio
     return metrics;
   }, setMetrics:function(xyRatio) {
     Blockly.BlockSpaceEditor.prototype.setBlockSpaceMetrics_.call(this, xyRatio);
-  }, hideTrashRect:true, readOnly:true, disableTooltip:true, noScrolling:opt_options.noScrolling});
+  }, hideTrashRect:true, readOnly:true, disableTooltip:true, noScrolling:opt_options.noScrolling, disableEventBindings:opt_options.disableEventBindings});
   var blockSpace = blockSpaceEditor.blockSpace;
   Blockly.Xml.domToBlockSpace(blockSpace, xml);
   return blockSpace;
@@ -18154,7 +18154,7 @@ Blockly.Generator.xmlToCode = function(name, xml) {
 };
 Blockly.Generator.xmlToBlocks = function(name, xml) {
   var div = document.createElement("div");
-  var blockSpace = Blockly.BlockSpace.createReadOnlyBlockSpace(div, xml);
+  var blockSpace = Blockly.BlockSpace.createReadOnlyBlockSpace(div, xml, {disableEventBindings:true});
   return blockSpace.getTopBlocks(true);
 };
 Blockly.Generator.blockSpaceToCode = function(name, opt_typeFilter, opt_showHidden) {
@@ -24996,7 +24996,7 @@ Blockly.BlockSpaceEditor = function(container, opt_options) {
   this.blockSpace = new Blockly.BlockSpace(this, goog.bind(this.getBlockSpaceMetrics_, this), goog.bind(this.setBlockSpaceMetrics_, this), container);
   this.blockLimits = new Blockly.BlockLimits;
   this.createDom_(container);
-  this.init_();
+  this.init_(!opt_options.disableEventBindings);
 };
 Blockly.BlockSpaceEditor.BUMP_ENTIRE_BLOCK = false;
 Blockly.BlockSpaceEditor.ENTIRE_BUMP_PADDING_TOP = 2;
@@ -25171,12 +25171,12 @@ Blockly.BlockSpaceEditor.prototype.bumpBlocksIntoBlockSpace = function() {
     }
   }, this);
 };
-Blockly.BlockSpaceEditor.prototype.init_ = function() {
+Blockly.BlockSpaceEditor.prototype.init_ = function(bindEvents) {
   this.detectBrokenControlPoints();
   this.blockSpace.bindBeginPanDragHandler(this.svg_, goog.bind(this.hideChaff, this));
   this.blockSpace.bindScrollOnWheelHandler(this.svg_);
   Blockly.bindEvent_(Blockly.WidgetDiv.DIV, "contextmenu", null, Blockly.blockContextMenu);
-  if (!Blockly.documentEventsBound_) {
+  if (bindEvents && !Blockly.documentEventsBound_) {
     Blockly.bindEvent_(window, "resize", this, this.svgResize);
     Blockly.bindEvent_(document, "keydown", this, this.onKeyDown_);
     if (goog.userAgent.IPAD) {

--- a/build-output/blockly_uncompressed.js
+++ b/build-output/blockly_uncompressed.js
@@ -24991,12 +24991,15 @@ Blockly.BlockSpaceEditor = function(container, opt_options) {
   if (opt_options.disableTooltip) {
     this.disableTooltip = opt_options.disableTooltip;
   }
+  if (opt_options.disableEventBindings) {
+    this.disableEventBindings = opt_options.disableEventBindings;
+  }
   this.readOnly_ = !!opt_options.readOnly;
   this.noScrolling_ = !!opt_options.noScrolling;
   this.blockSpace = new Blockly.BlockSpace(this, goog.bind(this.getBlockSpaceMetrics_, this), goog.bind(this.setBlockSpaceMetrics_, this), container);
   this.blockLimits = new Blockly.BlockLimits;
   this.createDom_(container);
-  this.init_(!opt_options.disableEventBindings);
+  this.init_();
 };
 Blockly.BlockSpaceEditor.BUMP_ENTIRE_BLOCK = false;
 Blockly.BlockSpaceEditor.ENTIRE_BUMP_PADDING_TOP = 2;
@@ -25171,12 +25174,12 @@ Blockly.BlockSpaceEditor.prototype.bumpBlocksIntoBlockSpace = function() {
     }
   }, this);
 };
-Blockly.BlockSpaceEditor.prototype.init_ = function(bindEvents) {
+Blockly.BlockSpaceEditor.prototype.init_ = function() {
   this.detectBrokenControlPoints();
   this.blockSpace.bindBeginPanDragHandler(this.svg_, goog.bind(this.hideChaff, this));
   this.blockSpace.bindScrollOnWheelHandler(this.svg_);
   Blockly.bindEvent_(Blockly.WidgetDiv.DIV, "contextmenu", null, Blockly.blockContextMenu);
-  if (bindEvents && !Blockly.documentEventsBound_) {
+  if (!this.disableEventBindings && !Blockly.documentEventsBound_) {
     Blockly.bindEvent_(window, "resize", this, this.svgResize);
     Blockly.bindEvent_(document, "keydown", this, this.onKeyDown_);
     if (goog.userAgent.IPAD) {

--- a/core/code_generation/generator.js
+++ b/core/code_generation/generator.js
@@ -122,7 +122,9 @@ Blockly.Generator.xmlToCode = function(name, xml) {
  */
 Blockly.Generator.xmlToBlocks = function(name, xml) {
   var div = document.createElement('div');
-  var blockSpace = Blockly.BlockSpace.createReadOnlyBlockSpace(div, xml);
+  var blockSpace = Blockly.BlockSpace.createReadOnlyBlockSpace(div, xml, {
+    disableEventBindings: true,
+  });
   return blockSpace.getTopBlocks(true);
 };
 

--- a/core/ui/block_space/block_space.js
+++ b/core/ui/block_space/block_space.js
@@ -185,6 +185,8 @@ Blockly.BlockSpace.SCROLLABLE_MARGIN_BELOW_BOTTOM = 100;
  * @param {Object} opt_options optional options
  * @param {boolean} opt_options.noScrolling whether or not to disable
  *        scrolling
+ * @param {boolean} opt_options.disableEventBindings whether or not to skip
+ *        setting up dom event handlers for this blockspace
  * @returns {Blockly.BlockSpace}
  */
 Blockly.BlockSpace.createReadOnlyBlockSpace = function (container, xml, opt_options) {
@@ -206,7 +208,8 @@ Blockly.BlockSpace.createReadOnlyBlockSpace = function (container, xml, opt_opti
     hideTrashRect: true,
     readOnly: true,
     disableTooltip: true,
-    noScrolling: opt_options.noScrolling
+    noScrolling: opt_options.noScrolling,
+    disableEventBindings: opt_options.disableEventBindings,
   });
 
   var blockSpace = blockSpaceEditor.blockSpace;

--- a/core/ui/block_space/block_space_editor.js
+++ b/core/ui/block_space/block_space_editor.js
@@ -70,6 +70,9 @@ Blockly.BlockSpaceEditor = function(container, opt_options) {
   if (opt_options.disableTooltip) {
     this.disableTooltip = opt_options.disableTooltip;
   }
+  if (opt_options.disableEventBindings) {
+    this.disableEventBindings = opt_options.disableEventBindings;
+  }
 
   this.readOnly_ = !!opt_options.readOnly;
   this.noScrolling_ = !!opt_options.noScrolling;
@@ -91,7 +94,7 @@ Blockly.BlockSpaceEditor = function(container, opt_options) {
   this.blockLimits = new Blockly.BlockLimits();
 
   this.createDom_(container);
-  this.init_(!opt_options.disableEventBindings);
+  this.init_();
 };
 
 /**
@@ -480,7 +483,7 @@ Blockly.BlockSpaceEditor.prototype.bumpBlocksIntoBlockSpace = function() {
 };
 
 
-Blockly.BlockSpaceEditor.prototype.init_ = function(bindEvents) {
+Blockly.BlockSpaceEditor.prototype.init_ = function() {
   this.detectBrokenControlPoints();
 
   // Bind pan-drag handlers
@@ -491,7 +494,7 @@ Blockly.BlockSpaceEditor.prototype.init_ = function(bindEvents) {
   Blockly.bindEvent_(Blockly.WidgetDiv.DIV, 'contextmenu', null,
     Blockly.blockContextMenu);
 
-  if (bindEvents && !Blockly.documentEventsBound_) {
+  if (!this.disableEventBindings && !Blockly.documentEventsBound_) {
     // Only bind the window/document events once.
     // Destroying and reinjecting Blockly should not bind again.
     Blockly.bindEvent_(window, 'resize', this, this.svgResize);

--- a/core/ui/block_space/block_space_editor.js
+++ b/core/ui/block_space/block_space_editor.js
@@ -52,6 +52,8 @@ goog.require('goog.style');
  *      BlockSpaceEditor.readOnly OR Blockly.readOnly are true
  * @param {boolean} opt_options.disableTooltip whether or not to disable tooltips for this
  *      blockSpace. It is recommended that only one blockSpace per page allow tooltips.
+ * @param {boolean} opt_options.disableEventBindings whether or not to skip setting up dom
+ *      event handlers for this blockspace
  */
 Blockly.BlockSpaceEditor = function(container, opt_options) {
   opt_options = opt_options || {};
@@ -89,7 +91,7 @@ Blockly.BlockSpaceEditor = function(container, opt_options) {
   this.blockLimits = new Blockly.BlockLimits();
 
   this.createDom_(container);
-  this.init_();
+  this.init_(!opt_options.disableEventBindings);
 };
 
 /**
@@ -477,7 +479,8 @@ Blockly.BlockSpaceEditor.prototype.bumpBlocksIntoBlockSpace = function() {
   }, this);
 };
 
-Blockly.BlockSpaceEditor.prototype.init_ = function() {
+
+Blockly.BlockSpaceEditor.prototype.init_ = function(bindEvents) {
   this.detectBrokenControlPoints();
 
   // Bind pan-drag handlers
@@ -488,7 +491,7 @@ Blockly.BlockSpaceEditor.prototype.init_ = function() {
   Blockly.bindEvent_(Blockly.WidgetDiv.DIV, 'contextmenu', null,
     Blockly.blockContextMenu);
 
-  if (!Blockly.documentEventsBound_) {
+  if (bindEvents && !Blockly.documentEventsBound_) {
     // Only bind the window/document events once.
     // Destroying and reinjecting Blockly should not bind again.
     Blockly.bindEvent_(window, 'resize', this, this.svgResize);


### PR DESCRIPTION
This fixes the workspace size issue that was still present on mobile safari on minecraft levels.

Handlers for DOM events are only set up for the first blockspace that gets created. Usually, the main workspace is that blockspace and everything is fine, but that changes when initialization blocks are present. The `xmlToBlocks` method creates a temporary blockspace, which steals the event handlers, and breaks resizing.

There's actually nothing specific to mobile safari about this, and it's almost completely unrelated to the very similar-looking bug I fixed last week in https://github.com/code-dot-org/code-dot-org/pull/18937. This bug is present for all browsers, for any level with initialization blocks, it's just way more noticeable on mobile safari because it automatically resizes right after loading the page.

My fix is to skip setting up the DOM event handlers for the temporary blockspace used in `xmlToBlocks`, allowing the actual workspace to get them instead.