### PR TITLE
Add .no-mc class to fix modal function editor button in MC

### DIFF
--- a/core/ui/function_editor.js
+++ b/core/ui/function_editor.js
@@ -896,7 +896,7 @@ Blockly.FunctionEditor.prototype.createParameterEditor_ = function() {
     '<div>' + Blockly.Msg.FUNCTION_PARAMETERS_LABEL + '</div>'
     + '<div>'
     + '<input id="paramAddText" type="text" style="width: 200px;"/> '
-    + '<button id="paramAddButton" class="btn">' + Blockly.Msg.ADD_PARAMETER + '</button>'
+    + '<button id="paramAddButton" class="btn no-mc">' + Blockly.Msg.ADD_PARAMETER + '</button>'
     + '</div>';
 };
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/413693/32969963-e9e5b0fc-cb9b-11e7-8653-29b4167f8cea.png)

After:

![image](https://user-images.githubusercontent.com/413693/32969981-f82b441a-cb9b-11e7-9247-ba71440bb4d5.png)