### PR TITLE
Update Circle config and package.json to more-recent versions of node

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   node:
-    version: 0.12.15
+    version: 6.9.0

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "url": "http://github.com/code-dot-org/blockly.git"
   },
   "engines": {
-    "node": ">=0.10.25 <0.13",
-    "npm": "^2.9.1"
+    "node": ">=6.7",
+    "npm": "^3.10.8"
   },
   "files": [
     "build-output",


### PR DESCRIPTION
Specifically, those same versions used by the main @code-dot-org repo.

The specific motivation to do so is that the phantomjs-prebuilt is
failing on the (really quite old) version of node that we're currently
using. See https://circleci.com/gh/code-dot-org/blockly/253