### PR TITLE
Use a transform to get RTL highlight from LTR path

### DIFF
--- a/core/connections/connection.js
+++ b/core/connections/connection.js
@@ -416,26 +416,23 @@ Blockly.Connection.prototype.moveBy = function(dx, dy) {
 Blockly.Connection.prototype.highlight = function() {
   var steps;
   if (this.type === Blockly.INPUT_VALUE || this.type === Blockly.OUTPUT_VALUE) {
-    var tabWidth = Blockly.RTL ? -Blockly.BlockSvg.TAB_WIDTH :
-                                 Blockly.BlockSvg.TAB_WIDTH;
-    steps = 'm 0,0 v 5 c 0,10 ' + -tabWidth + ',-8 ' + -tabWidth + ',7.5 s ' +
-            tabWidth + ',-2.5 ' + tabWidth + ',7.5 v 5';
+    steps = 'm 0,0 '+ Blockly.BlockSvg.TAB_PATH_DOWN + ' v 5';
   } else {
     var moveWidth = 5 + Blockly.BlockSvg.NOTCH_PATH_WIDTH;
     var notchPaths = this.getNotchPaths();
-    if (Blockly.RTL) {
-      steps = 'm ' + moveWidth + ',0 h -5 ' + notchPaths.right + ' h -5';
-    } else {
-      steps = 'm -' + moveWidth + ',0 h 5 ' + notchPaths.left + ' h 5';
-    }
+    steps = 'm -' + moveWidth + ',0 h 5 ' + notchPaths.left + ' h 5';
   }
   var xy = this.sourceBlock_.getRelativeToSurfaceXY();
   var x = this.x_ - xy.x;
   var y = this.y_ - xy.y;
+  var transform  = 'translate(' + x + ', ' + y + ')';
+  if (Blockly.RTL) {
+    transform += ' scale(-1, 1)';
+  }
   Blockly.Connection.highlightedPath_ = Blockly.createSvgElement('path',
       {'class': 'blocklyHighlightedConnectionPath',
        'd': steps,
-       transform: 'translate(' + x + ', ' + y + ')'},
+       transform: transform},
       this.sourceBlock_.getSvgRoot());
 };
 


### PR DESCRIPTION
I'm working on changing the tab shape for sprite blocks, here's some tangentially related cleanup.

This code draws the connection highlight that appears when you drag a block close to a connection on another block, either the previous/next connection or an input/output connection.

I'm reusing the existing `TAB_PATH_DOWN` constant instead of duplicating the svg path for the input/output highlight. I'm also applying an svg transform to flip it for RTL mode, which is how that's handled for most other block svg stuff.