### PR TITLE
Use a curve that's actually 50px tall to check for bbox bug

### DIFF
--- a/core/ui/block_space/block_space_editor.js
+++ b/core/ui/block_space/block_space_editor.js
@@ -558,7 +558,7 @@ Blockly.BlockSpaceEditor.prototype.detectBrokenControlPoints = function() {
      */
     var container = Blockly.createSvgElement('g', {}, this.svg_);
     Blockly.createSvgElement('path',
-      {'d': 'm 0,0 c 0,-5 0,-5 0,0 H 50 V 50 z'}, container);
+      {'d': 'M 0,50 C 75,-25 75,50 125,0 Z'}, container);
     if (Blockly.isMsie() || Blockly.isTrident()) {
       container.style.display = "inline";
       /* reqd for IE */

--- a/core/ui/block_space/block_space_editor.js
+++ b/core/ui/block_space/block_space_editor.js
@@ -548,13 +548,9 @@ Blockly.BlockSpaceEditor.prototype.detectBrokenControlPoints = function() {
      If the getBBox function returns a height of 55px instead of 50px, then
      this browser has broken control points.
 
-     NOTE:
-     chromium fixed this bug for path elements in commit 8f4c8e;
-     (https://chromium.googlesource.com/chromium/src.git/+/8f4c8e6d2f1260d68f387b37f078457e4153bbb4)
-     unfortunately, the bug still presents itself when getBBox is called
-     on containers that CONTAIN such a path element, which is our actual
-     use case. Thus, we draw the shape within a container and check the
-     size of the container.
+     This was fixed in Chrome 63. BROKEN_CONTROL_POINTS and all this detector
+     code can be removed when we drop support for Chrome versions older than
+     that.
      */
     var container = Blockly.createSvgElement('g', {}, this.svg_);
     Blockly.createSvgElement('path',


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/blockly/pull/7

Chrome has since fixed https://bugs.chromium.org/p/chromium/issues/detail?id=230599, but our bug-detector is giving us false positives. The current test path actually does extend into negative-y terroritory, so chrome correctly reports it as having a height greater than 50: 
![image](https://user-images.githubusercontent.com/1070243/37547608-f5ec784e-292f-11e8-8d3a-aabcf5d88297.png)
The triangle has a height and width of 50, the little notch at the top left is the bezier curve you get by going from (0,0) to (0,0) with both control points at (0, -5)

I'm replacing it with a curve that extends from (0, 50) to (125, 0), with the first control point at (75, -25). This catches older versions of chrome that include the control point, and thus report the height as 75px, but not newer ones that correctly determine that the curve stays on the sunny side of the x-axis:
![image](https://user-images.githubusercontent.com/1070243/37548286-e9e9c5ac-2933-11e8-8a82-e7afef83b157.png)
 