### PR TITLE
Remove header divider line from functional param get block

### DIFF
--- a/blocks/functional_parameters.js
+++ b/blocks/functional_parameters.js
@@ -36,9 +36,7 @@ Blockly.Blocks.functional_parameters_get = {
     fieldLabel.EDITABLE = true;
     this.setHelpUrl(Blockly.Msg.VARIABLES_GET_HELPURL);
     this.setHSV(312, 0.32, 0.62);
-    this.setFunctional(true, {
-      headerHeight: 30
-    });
+    this.setFunctional(true);
     var options = {
       fixedSize: { height: 35 }
     };


### PR DESCRIPTION
Some functional blocks have a "header" section with a dividing line underneath, e.g the `+` block below, and this was needlessly added to the `functional_parameters_get` block. Despite the fact that it's not even visible (it's outside the block's `clip-path`), the line is messing up the height calculation and creating an ugly gap in the input slot.

![image](https://user-images.githubusercontent.com/1070243/37686143-73b6ddfc-2c53-11e8-8b71-8e128ae6586c.png)
