### PR TITLE
Clean up the dom after every test

### DIFF
--- a/tests/block_space_test.js
+++ b/tests/block_space_test.js
@@ -167,7 +167,8 @@ function test_blockSpaceAutoPositioning() {
     assertEquals(expected_positions[i][1], position.y);
   }
 
-  goog.dom.removeNode(container);
+  // phantomJS hangs if you try to remove container from the DOM, just hide it
+  goog.style.setElementShown(container, false);
 }
 
 function test_blockSpace_isReadOnly() {

--- a/tests/block_space_test.js
+++ b/tests/block_space_test.js
@@ -160,12 +160,14 @@ function test_blockSpaceAutoPositioning() {
   var blockXML = '<xml>' + blocks.join('') + '</xml>';
   Blockly.Xml.domToBlockSpace(Blockly.mainBlockSpace, Blockly.Xml.textToDom(blockXML));
   var topBlocks = Blockly.mainBlockSpace.getTopBlocks();
-  
+
   for (var i = 0; i < topBlocks.length; i++) {
     var position = topBlocks[i].getRelativeToSurfaceXY();
     assertEquals(expected_positions[i][0], position.x);
     assertEquals(expected_positions[i][1], position.y);
   }
+
+  goog.dom.removeNode(container);
 }
 
 function test_blockSpace_isReadOnly() {
@@ -210,13 +212,16 @@ function test_readOnlyBlockSpaceCanRender() {
 }
 
 function test_blockSpacesUseSameWidgetDiv() {
-  Blockly.Test.initializeBlockSpaceEditor();
+  var container = Blockly.Test.initializeBlockSpaceEditor();
   var first = Blockly.WidgetDiv;
   assertNotNull(first);
-  Blockly.Test.initializeBlockSpaceEditor();
+  var container2 = Blockly.Test.initializeBlockSpaceEditor();
   var second = Blockly.WidgetDiv;
   assertNotNull(second);
   assertEquals(first, second);
+
+  goog.dom.removeNode(container);
+  goog.dom.removeNode(container2);
 }
 
 function test_blockSpaceWithLimitedQuantitiesOfBlocks() {

--- a/tests/blocks_test.js
+++ b/tests/blocks_test.js
@@ -120,6 +120,8 @@ function test_checkAllowedConnectionType() {
   assertConnectionAllowed(noneTypeOutput, nonStrictInput);
   assertConnectionAllowed(noneTypeOutput, otherTypeInput);
   assertConnectionAllowed(noneTypeOutput, noneTypeInput);
+
+  goog.dom.removeNode(containerDiv);
 }
 
 function test_clickIntoEditableUnmovableBlock() {
@@ -200,10 +202,11 @@ function test_setBlockNextConnectionDisabled() {
   assert(block.nextConnectionDisabled_ === true);
   assertNull(block.nextConnection);
 
+  goog.dom.removeNode(containerDiv);
 }
 
 function test_visibleThroughParent() {
-  Blockly.Test.initializeBlockSpaceEditor();
+  var containerDiv = Blockly.Test.initializeBlockSpaceEditor();
   var blockSpace = Blockly.mainBlockSpace;
 
   Blockly.Xml.domToBlockSpace(blockSpace, Blockly.Xml.textToDom(
@@ -229,10 +232,12 @@ function test_visibleThroughParent() {
 
   assert(parentBlock.isVisible() === false);
   assert(childBlock.isVisible() === false);
+
+  goog.dom.removeNode(containerDiv);
 }
 
 function test_isVisible() {
-  Blockly.Test.initializeBlockSpaceEditor();
+  var containerDiv = Blockly.Test.initializeBlockSpaceEditor();
   var blockSpace = Blockly.mainBlockSpace;
 
   Blockly.Xml.domToBlockSpace(blockSpace, Blockly.Xml.textToDom(
@@ -269,6 +274,8 @@ function test_isVisible() {
   // finally, restore the editBlocks state to avoid polluting future
   // tests
   Blockly.editBlocks = original_editBlocks_state;
+
+  goog.dom.removeNode(containerDiv);
 }
 
 function test_blockSetIsUnused() {

--- a/tests/hidden_blocks_test.js
+++ b/tests/hidden_blocks_test.js
@@ -80,7 +80,7 @@ var NESTED_HIDDEN_VAR_REASSIGNMENT =
   '</xml>';
 
 function test_showHiddenDefaultsToTrue() {
-  Blockly.Test.initializeBlockSpaceEditor();
+  var container = Blockly.Test.initializeBlockSpaceEditor();
   var blockSpace = Blockly.mainBlockSpace;
 
   Blockly.Xml.domToBlockSpace(blockSpace, Blockly.Xml.textToDom(
@@ -89,10 +89,12 @@ function test_showHiddenDefaultsToTrue() {
   var generatedCode =
       Blockly.Generator.blockSpaceToCode('JavaScript');
   assertEquals(2, eval(generatedCode));
+
+  goog.dom.removeNode(container);
 }
 
 function test_showHiddenTrue() {
-  Blockly.Test.initializeBlockSpaceEditor();
+  var container = Blockly.Test.initializeBlockSpaceEditor();
   var blockSpace = Blockly.mainBlockSpace;
 
   Blockly.Xml.domToBlockSpace(blockSpace, Blockly.Xml.textToDom(
@@ -101,10 +103,12 @@ function test_showHiddenTrue() {
   var generatedCode =
       Blockly.Generator.blockSpaceToCode('JavaScript', null, true);
   assertEquals(2, eval(generatedCode));
+
+  goog.dom.removeNode(container);
 }
 
 function test_showHiddenTrue_nested() {
-  Blockly.Test.initializeBlockSpaceEditor();
+  var container = Blockly.Test.initializeBlockSpaceEditor();
   var blockSpace = Blockly.mainBlockSpace;
 
   Blockly.Xml.domToBlockSpace(blockSpace, Blockly.Xml.textToDom(
@@ -113,10 +117,12 @@ function test_showHiddenTrue_nested() {
   var generatedCode =
       Blockly.Generator.blockSpaceToCode('JavaScript', null, true);
   assertEquals(3, eval(generatedCode));
+
+  goog.dom.removeNode(container);
 }
 
 function test_showHiddenFalse() {
-  Blockly.Test.initializeBlockSpaceEditor();
+  var container = Blockly.Test.initializeBlockSpaceEditor();
   var blockSpace = Blockly.mainBlockSpace;
 
   Blockly.Xml.domToBlockSpace(blockSpace, Blockly.Xml.textToDom(
@@ -125,10 +131,12 @@ function test_showHiddenFalse() {
   var generatedCode =
       Blockly.Generator.blockSpaceToCode('JavaScript', null, false)
   assertEquals(1, eval(generatedCode));
+
+  goog.dom.removeNode(container);
 }
 
 function test_showHiddenFalse_nested() {
-  Blockly.Test.initializeBlockSpaceEditor();
+  var container = Blockly.Test.initializeBlockSpaceEditor();
   var blockSpace = Blockly.mainBlockSpace;
 
   Blockly.Xml.domToBlockSpace(blockSpace, Blockly.Xml.textToDom(
@@ -137,5 +145,7 @@ function test_showHiddenFalse_nested() {
   var generatedCode =
       Blockly.Generator.blockSpaceToCode('JavaScript', null, false)
   assertEquals(3, eval(generatedCode));
+
+  goog.dom.removeNode(container);
 }
 

--- a/tests/test_requires_and_utils.js
+++ b/tests/test_requires_and_utils.js
@@ -59,5 +59,5 @@ Blockly.Test.testWithReadOnlyBlockSpaceEditor = function (callback) {
     readOnly: true
   });
   callback(blockSpaceEditor);
-  return container;
+  goog.dom.removeNode(container);
 };

--- a/tests/unused_blocks_test.js
+++ b/tests/unused_blocks_test.js
@@ -57,7 +57,7 @@ var DISCONNECTED_INLINE_BLOCKS =
 
 function test_unattachedBlocks() {
   var orig = Blockly.showUnusedBlocks;
-  Blockly.Test.initializeBlockSpaceEditor();
+  var container = Blockly.Test.initializeBlockSpaceEditor();
   var blockSpace = Blockly.mainBlockSpace;
 
   var expectedCode = [
@@ -78,11 +78,13 @@ function test_unattachedBlocks() {
   });
 
   Blockly.showUnusedBlocks = orig;
+
+  goog.dom.removeNode(container);
 }
 
 function test_unattachedInlineBlocks() {
   var orig = Blockly.showUnusedBlocks;
-  Blockly.Test.initializeBlockSpaceEditor();
+  var container = Blockly.Test.initializeBlockSpaceEditor();
   var blockSpace = Blockly.mainBlockSpace;
 
   var expectedCode = [
@@ -99,4 +101,6 @@ function test_unattachedInlineBlocks() {
   });
 
   Blockly.showUnusedBlocks = orig;
+
+  goog.dom.removeNode(container);
 }


### PR DESCRIPTION
Turns out there's a nice test report when you load `blockly/tests/blockly_test.html` to run our unit tests in a browser. I've never seen it before because it got pushed way off the bottom of the page by all the `div`s left lying around by our unit tests.