### PR TITLE
Only count used blocks towards the toolbox block limits

### DIFF
--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -787,7 +787,7 @@ Blockly.Flyout.prototype.filterForCapacity_ = function() {
 };
 
 Blockly.Flyout.prototype.updateBlockLimitTotals_ = function() {
-  var blocks = this.blockSpaceEditor_.blockSpace.getAllVisibleBlocks();
+  var blocks = this.blockSpaceEditor_.blockSpace.getAllUsedBlocks();
   var blockTypes = blocks.map(function (block) {
     return block.type;
   });


### PR DESCRIPTION
Fixes https://codeorg.zendesk.com/agent/tickets/137867.

Unfortunately we don't have any existing test coverage for `flyout.js`.  I'll get this tracked on the tech debt backlog.