### PR TITLE
Add variable categories

### DIFF
--- a/blocks/functional_procedures.js
+++ b/blocks/functional_procedures.js
@@ -211,11 +211,10 @@ Blockly.Blocks.functional_definition = {
       isFunctionalVariable: this.isFunctionalVariable_
     }
   },
-  getVars: function(category) {
-    if (category && category !== Blockly.Variables.DEFAULT_CATEGORY) {
-      return [];
-    }
-    return this.parameterNames_;
+  getVars: function() {
+    return {
+      Default: this.parameterNames_,
+    };
   },
   renameVar: function(oldName, newName) {
     var change = false;

--- a/blocks/functional_procedures.js
+++ b/blocks/functional_procedures.js
@@ -212,7 +212,7 @@ Blockly.Blocks.functional_definition = {
     }
   },
   getVars: function(category) {
-    if (category) {
+    if (category && category !== Blockly.Variables.DEFAULT_CATEGORY) {
       return [];
     }
     return this.parameterNames_;

--- a/blocks/functional_procedures.js
+++ b/blocks/functional_procedures.js
@@ -211,7 +211,10 @@ Blockly.Blocks.functional_definition = {
       isFunctionalVariable: this.isFunctionalVariable_
     }
   },
-  getVars: function() {
+  getVars: function(category) {
+    if (category) {
+      return [];
+    }
     return this.parameterNames_;
   },
   renameVar: function(oldName, newName) {

--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -117,7 +117,7 @@ Blockly.Blocks.controls_for = {
     });
   },
   getVars: function(category) {
-    if (category) {
+    if (category && category !== Blockly.Variables.DEFAULT_CATEGORY) {
       return [];
     }
     return [this.getTitleValue('VAR')];
@@ -174,7 +174,7 @@ Blockly.Blocks.controls_forEach = {
     });
   },
   getVars: function(category) {
-    if (category) {
+    if (category && category !== Blockly.Variables.DEFAULT_CATEGORY) {
       return [];
     }
     return [this.getTitleValue('VAR')];

--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -116,12 +116,7 @@ Blockly.Blocks.controls_for = {
           thisBlock.getTitleValue('VAR'));
     });
   },
-  getVars: function(category) {
-    if (category && category !== Blockly.Variables.DEFAULT_CATEGORY) {
-      return [];
-    }
-    return [this.getTitleValue('VAR')];
-  },
+  getVars: Blockly.Variables.getVars,
   renameVar: function(oldName, newName) {
     if (Blockly.Names.equals(oldName, this.getTitleValue('VAR'))) {
       this.setTitleValue(newName, 'VAR');
@@ -173,12 +168,7 @@ Blockly.Blocks.controls_forEach = {
           thisBlock.getTitleValue('VAR'));
     });
   },
-  getVars: function(category) {
-    if (category && category !== Blockly.Variables.DEFAULT_CATEGORY) {
-      return [];
-    }
-    return [this.getTitleValue('VAR')];
-  },
+  getVars: Blockly.Variables.getVars,
   renameVar: function(oldName, newName) {
     if (Blockly.Names.equals(oldName, this.getTitleValue('VAR'))) {
       this.setTitleValue(newName, 'VAR');

--- a/blocks/loops.js
+++ b/blocks/loops.js
@@ -116,7 +116,10 @@ Blockly.Blocks.controls_for = {
           thisBlock.getTitleValue('VAR'));
     });
   },
-  getVars: function() {
+  getVars: function(category) {
+    if (category) {
+      return [];
+    }
     return [this.getTitleValue('VAR')];
   },
   renameVar: function(oldName, newName) {
@@ -170,7 +173,10 @@ Blockly.Blocks.controls_forEach = {
           thisBlock.getTitleValue('VAR'));
     });
   },
-  getVars: function() {
+  getVars: function(category) {
+    if (category) {
+      return [];
+    }
     return [this.getTitleValue('VAR')];
   },
   renameVar: function(oldName, newName) {

--- a/blocks/math.js
+++ b/blocks/math.js
@@ -233,7 +233,10 @@ Blockly.Blocks.math_change = {
           thisBlock.getTitleValue('VAR'));
     });
   },
-  getVars: function() {
+  getVars: function(category) {
+    if (category) {
+      return [];
+    }
     return [this.getTitleValue('VAR')];
   },
   renameVar: function(oldName, newName) {

--- a/blocks/math.js
+++ b/blocks/math.js
@@ -233,12 +233,7 @@ Blockly.Blocks.math_change = {
           thisBlock.getTitleValue('VAR'));
     });
   },
-  getVars: function(category) {
-    if (category && category !== Blockly.Variables.DEFAULT_CATEGORY) {
-      return [];
-    }
-    return [this.getTitleValue('VAR')];
-  },
+  getVars: Blockly.Variables.getVars,
   renameVar: function(oldName, newName) {
     if (Blockly.Names.equals(oldName, this.getTitleValue('VAR'))) {
       this.setTitleValue(newName, 'VAR');

--- a/blocks/math.js
+++ b/blocks/math.js
@@ -234,7 +234,7 @@ Blockly.Blocks.math_change = {
     });
   },
   getVars: function(category) {
-    if (category) {
+    if (category && category !== Blockly.Variables.DEFAULT_CATEGORY) {
       return [];
     }
     return [this.getTitleValue('VAR')];

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -187,7 +187,7 @@ Blockly.Blocks.procedures_defnoreturn = {
     };
   },
   getVars: function(category) {
-    if (category) {
+    if (category && category !== Blockly.Variables.DEFAULT_CATEGORY) {
       return [];
     }
     return this.parameterNames_;

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -186,11 +186,10 @@ Blockly.Blocks.procedures_defnoreturn = {
       callType: this.callType_
     };
   },
-  getVars: function(category) {
-    if (category && category !== Blockly.Variables.DEFAULT_CATEGORY) {
-      return [];
-    }
-    return this.parameterNames_;
+  getVars: function() {
+    return {
+      Default: this.parameterNames_,
+    };
   },
   renameVar: function(oldName, newName) {
     var change = false;

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -186,7 +186,10 @@ Blockly.Blocks.procedures_defnoreturn = {
       callType: this.callType_
     };
   },
-  getVars: function() {
+  getVars: function(category) {
+    if (category) {
+      return [];
+    }
     return this.parameterNames_;
   },
   renameVar: function(oldName, newName) {

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -185,12 +185,7 @@ Blockly.Blocks.text_append = {
           thisBlock.getTitleValue('VAR'));
     });
   },
-  getVars: function(category) {
-    if (category && category !== Blockly.Variables.DEFAULT_CATEGORY) {
-      return [];
-    }
-    return [this.getTitleValue('VAR')];
-  },
+  getVars: Blockly.Variables.getVars,
   renameVar: function(oldName, newName) {
     if (Blockly.Names.equals(oldName, this.getTitleValue('VAR'))) {
       this.setTitleValue(newName, 'VAR');

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -186,7 +186,7 @@ Blockly.Blocks.text_append = {
     });
   },
   getVars: function(category) {
-    if (category) {
+    if (category && category !== Blockly.Variables.DEFAULT_CATEGORY) {
       return [];
     }
     return [this.getTitleValue('VAR')];

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -185,7 +185,10 @@ Blockly.Blocks.text_append = {
           thisBlock.getTitleValue('VAR'));
     });
   },
-  getVars: function() {
+  getVars: function(category) {
+    if (category) {
+      return [];
+    }
     return [this.getTitleValue('VAR')];
   },
   renameVar: function(oldName, newName) {

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -45,7 +45,7 @@ Blockly.Blocks.variables_get = {
     this.setTooltip(Blockly.Msg.VARIABLES_GET_TOOLTIP);
   },
   getVars: function(category) {
-    if (category) {
+    if (category && category !== Blockly.Variables.DEFAULT_CATEGORY) {
       return [];
     }
     return [this.getTitleValue('VAR')];
@@ -92,7 +92,7 @@ Blockly.Blocks.variables_set = {
     this.setTooltip(Blockly.Msg.VARIABLES_SET_TOOLTIP);
   },
   getVars: function(category) {
-    if (category) {
+    if (category && category !== Blockly.Variables.DEFAULT_CATEGORY) {
       return [];
     }
     return [this.getTitleValue('VAR')];

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -44,7 +44,10 @@ Blockly.Blocks.variables_get = {
     this.setOutput(true);
     this.setTooltip(Blockly.Msg.VARIABLES_GET_TOOLTIP);
   },
-  getVars: function() {
+  getVars: function(category) {
+    if (category) {
+      return [];
+    }
     return [this.getTitleValue('VAR')];
   },
   renameVar: function(oldName, newName) {
@@ -88,7 +91,10 @@ Blockly.Blocks.variables_set = {
     this.setNextStatement(true);
     this.setTooltip(Blockly.Msg.VARIABLES_SET_TOOLTIP);
   },
-  getVars: function() {
+  getVars: function(category) {
+    if (category) {
+      return [];
+    }
     return [this.getTitleValue('VAR')];
   },
   renameVar: function(oldName, newName) {

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -44,12 +44,7 @@ Blockly.Blocks.variables_get = {
     this.setOutput(true);
     this.setTooltip(Blockly.Msg.VARIABLES_GET_TOOLTIP);
   },
-  getVars: function(category) {
-    if (category && category !== Blockly.Variables.DEFAULT_CATEGORY) {
-      return [];
-    }
-    return [this.getTitleValue('VAR')];
-  },
+  getVars: Blockly.Variables.getVars,
   renameVar: function(oldName, newName) {
     if (Blockly.Names.equals(oldName, this.getTitleValue('VAR'))) {
       this.setTitleValue(newName, 'VAR');
@@ -91,12 +86,7 @@ Blockly.Blocks.variables_set = {
     this.setNextStatement(true);
     this.setTooltip(Blockly.Msg.VARIABLES_SET_TOOLTIP);
   },
-  getVars: function(category) {
-    if (category && category !== Blockly.Variables.DEFAULT_CATEGORY) {
-      return [];
-    }
-    return [this.getTitleValue('VAR')];
-  },
+  getVars: Blockly.Variables.getVars,
   renameVar: function(oldName, newName) {
     if (Blockly.Names.equals(oldName, this.getTitleValue('VAR'))) {
       this.setTitleValue(newName, 'VAR');

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -444,9 +444,8 @@ Blockly.Flyout.prototype.show = function(xmlList) {
     // Allow for a mix of static + dynamic blocks. Static blocks will appear
     // first in the category
     this.layoutXmlToBlocks_(xmlList.slice(1), blocks, gaps, margin);
-    Blockly.Variables.flyoutCategory(
-      blocks, gaps, margin, this.blockSpace_,
-      null /* category */, true /* addDefaultVar */);
+    Blockly.Variables.flyoutCategory(blocks, gaps, margin, this.blockSpace_,
+      Blockly.Variables.DEFAULT_CATEGORY, true /* addDefaultVar */);
   } else if (firstBlock === Blockly.Procedures.NAME_TYPE ||
     Blockly.topLevelProcedureAutopopulate) {
     // Special category for procedures.
@@ -480,11 +479,6 @@ Blockly.Flyout.prototype.show = function(xmlList) {
     );
   } else if (goog.isString(firstBlock)) {
     var addDefaultVar = true;
-    var config = Blockly.Flyout.config[firstBlock];
-    if (config) {
-      config.initialize(this, cursor);
-      addDefaultVar = config.addDefaultVar;
-    }
     // Special category for categorized variables.
     // Allow for a mix of static + dynamic blocks. Static blocks will appear
     // first in the category

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -444,7 +444,9 @@ Blockly.Flyout.prototype.show = function(xmlList) {
     // Allow for a mix of static + dynamic blocks. Static blocks will appear
     // first in the category
     this.layoutXmlToBlocks_(xmlList.slice(1), blocks, gaps, margin);
-    Blockly.Variables.flyoutCategory(blocks, gaps, margin, this.blockSpace_);
+    Blockly.Variables.flyoutCategory(
+      blocks, gaps, margin, this.blockSpace_,
+      null /* category */, true /* addDefaultVar */);
   } else if (firstBlock === Blockly.Procedures.NAME_TYPE ||
     Blockly.topLevelProcedureAutopopulate) {
     // Special category for procedures.
@@ -476,6 +478,19 @@ Blockly.Flyout.prototype.show = function(xmlList) {
       this.blockSpace_,
       function(procedureInfo) { return procedureInfo.isFunctionalVariable; }
     );
+  } else if (goog.isString(firstBlock)) {
+    var addDefaultVar = true;
+    var config = Blockly.Flyout.config[firstBlock];
+    if (config) {
+      config.initialize(this, cursor);
+      addDefaultVar = config.addDefaultVar;
+    }
+    // Special category for categorized variables.
+    // Allow for a mix of static + dynamic blocks. Static blocks will appear
+    // first in the category
+    this.layoutXmlToBlocks_(xmlList.slice(1), blocks, gaps, margin);
+    Blockly.Variables.flyoutCategory(
+      blocks, gaps, margin, this.blockSpace_, firstBlock, addDefaultVar);
   } else {
     this.layoutXmlToBlocks_(xmlList, blocks, gaps, margin);
   }

--- a/core/ui/fields/field_variable.js
+++ b/core/ui/fields/field_variable.js
@@ -36,10 +36,16 @@ goog.require('Blockly.Variables');
  * @param {?Function} opt_changeHandler A function that is executed when a new
  *     option is selected.
  * @param {?Function} opt_createHandler A function that is executed after creation
+ * @param {?string} opt_category Only show variables from this category
  * @extends {Blockly.FieldDropdown}
  * @constructor
  */
-Blockly.FieldVariable = function(varname, opt_changeHandler, opt_createHandler) {
+Blockly.FieldVariable = function(
+    varname,
+    opt_changeHandler,
+    opt_createHandler,
+    opt_category) {
+  this.category = opt_category;
   var changeHandler;
   if (opt_changeHandler === Blockly.FieldParameter.dropdownChange) {
     changeHandler = opt_changeHandler;
@@ -100,7 +106,7 @@ Blockly.FieldVariable.prototype.setValue = function(text) {
  * @this {!Blockly.FieldVariable}
  */
 Blockly.FieldVariable.dropdownCreate = function() {
-  var variableList = Blockly.Variables.allVariables();
+  var variableList = Blockly.Variables.allVariables(null, this.category);
   // Ensure that the currently selected variable is an option.
   var name = this.getText();
   if (name && variableList.indexOf(name) == -1) {

--- a/core/ui/fields/field_variable.js
+++ b/core/ui/fields/field_variable.js
@@ -45,7 +45,7 @@ Blockly.FieldVariable = function(
     opt_changeHandler,
     opt_createHandler,
     opt_category) {
-  this.category = opt_category;
+  this.category = opt_category || Blockly.Variables.DEFAULT_CATEGORY;
   var changeHandler;
   if (opt_changeHandler === Blockly.FieldParameter.dropdownChange) {
     changeHandler = opt_changeHandler;

--- a/core/utils/block_value_type.js
+++ b/core/utils/block_value_type.js
@@ -19,7 +19,21 @@ Blockly.BlockValueType = {
   FUNCTION: 'Function',
   COLOUR: 'Colour',
   ARRAY: 'Array',
+
+  // p5.play Sprite
   SPRITE: 'Sprite',
+
+  /**
+   * {Object} Behavior
+   * {function} Behavior.func
+   * {Array} Behavior.extraArgs
+   */
   BEHAVIOR: 'Behavior',
+
+  /**
+   * {Object} Location
+   * {number} Location.x
+   * {number} Location.y
+   */
   LOCATION: 'Location',
 };

--- a/core/utils/variables.js
+++ b/core/utils/variables.js
@@ -51,7 +51,8 @@ Blockly.Variables.DEFAULT_CATEGORY = 'Default';
  */
 Blockly.Variables.allVariables = function(opt_blocks, opt_category) {
   if (opt_category && opt_category !== Blockly.Variables.DEFAULT_CATEGORY &&
-      !Object.keys(Blockly.valueTypeTabShapeMap).includes(opt_category)) {
+      (Blockly.valueTypeTabShapeMap &&
+      Object.keys(Blockly.valueTypeTabShapeMap).indexOf(opt_category) === -1)) {
     throw new Error('Variable category must be "Default" or a strict type');
   }
   var blocks;

--- a/core/utils/variables.js
+++ b/core/utils/variables.js
@@ -52,7 +52,7 @@ Blockly.Variables.DEFAULT_CATEGORY = 'Default';
 Blockly.Variables.allVariables = function(opt_blocks, opt_category) {
   if (opt_category && opt_category !== Blockly.Variables.DEFAULT_CATEGORY &&
       (Blockly.valueTypeTabShapeMap &&
-      Object.keys(Blockly.valueTypeTabShapeMap).indexOf(opt_category) === -1)) {
+      Blockly.valueTypeTabShapeMap[opt_category] === undefined)) {
     throw new Error('Variable category must be "Default" or a strict type');
   }
   var blocks;

--- a/core/utils/variables.js
+++ b/core/utils/variables.js
@@ -43,9 +43,10 @@ Blockly.Variables.NAME_TYPE_LOCAL = 'LOCALVARIABLE';
  * Find all user-created variables.
  * Currently searches the main blockspace only
  * @param {Array.<Blockly.Block>=} opt_blocks Optional root blocks.
+ * @param {string=} opt_category only return variables in this category
  * @return {!Array.<string>} Array of variable names.
  */
-Blockly.Variables.allVariables = function(opt_blocks) {
+Blockly.Variables.allVariables = function(opt_blocks, opt_category) {
   var blocks;
   if (opt_blocks) {
     opt_blocks = Array.isArray(opt_blocks) ? opt_blocks : [opt_blocks];
@@ -62,7 +63,7 @@ Blockly.Variables.allVariables = function(opt_blocks) {
   for (var x = 0; x < blocks.length; x++) {
     var func = blocks[x].getVars;
     if (func) {
-      var blockVariables = func.call(blocks[x]);
+      var blockVariables = func.call(blocks[x], opt_category);
       for (var y = 0; y < blockVariables.length; y++) {
         var varName = blockVariables[y];
         // Variable name may be null if the block is only half-built.
@@ -155,7 +156,7 @@ Blockly.Variables.flyoutCategory = function(blocks, gaps, margin, blockSpace) {
         new Blockly.Block(blockSpace, 'variables_set') : null;
     setBlock && setBlock.initSvg();
     if (variableList[i] === null) {
-      defaultVariable = (getBlock || setBlock).getVars()[0];
+      defaultVariable = (getBlock || setBlock).getVars(null)[0];
     } else {
       getBlock && getBlock.setTitleValue(variableList[i], 'VAR');
       setBlock && setBlock.setTitleValue(variableList[i], 'VAR');

--- a/core/utils/variables.js
+++ b/core/utils/variables.js
@@ -39,14 +39,21 @@ goog.require('Blockly.BlockSpace');
 Blockly.Variables.NAME_TYPE = 'VARIABLE';
 Blockly.Variables.NAME_TYPE_LOCAL = 'LOCALVARIABLE';
 
+Blockly.Variables.DEFAULT_CATEGORY = 'Default';
+
 /**
  * Find all user-created variables.
  * Currently searches the main blockspace only
  * @param {Array.<Blockly.Block>=} opt_blocks Optional root blocks.
- * @param {string=} opt_category only return variables in this category
+ * @param {string=} opt_category only return variables in this category, or all
+ *   variables if not specified
  * @return {!Array.<string>} Array of variable names.
  */
 Blockly.Variables.allVariables = function(opt_blocks, opt_category) {
+  if (opt_category && opt_category !== Blockly.Variables.DEFAULT_CATEGORY &&
+      !Object.keys(Blockly.valueTypeTabShapeMap).includes(opt_category)) {
+    throw new Error('Variable category must be "Default" or a strict type');
+  }
   var blocks;
   if (opt_blocks) {
     opt_blocks = Array.isArray(opt_blocks) ? opt_blocks : [opt_blocks];
@@ -180,18 +187,20 @@ Blockly.Variables.flyoutCategory = function(
   }
 };
 
-Blockly.Variables.getters = {};
+Blockly.Variables.getters = {
+  'Default': 'variables_get',
+};
 Blockly.Variables.getGetter = function(blockSpace, category) {
-  var getterName = category ? Blockly.Variables.getters[category] :
-    'variables_get';
+  var getterName = Blockly.Variables.getters[category];
   return (getterName && Blockly.Blocks[getterName]) ?
       new Blockly.Block(blockSpace, getterName) : null;
 };
 
-Blockly.Variables.setters = {};
+Blockly.Variables.setters = {
+  'Default': 'variables_set',
+};
 Blockly.Variables.getSetter = function(blockSpace, category) {
-  var setterName = category ? Blockly.Variables.setters[category] :
-    'variables_set';
+  var setterName = Blockly.Variables.setters[category];
   return (setterName && Blockly.Blocks[setterName]) ?
       new Blockly.Block(blockSpace, setterName) : null;
 };
@@ -208,11 +217,6 @@ Blockly.Variables.generateUniqueName = function(baseName) {
   }
 
   var variableList = Blockly.Variables.allVariables();
-  Object.keys(Blockly.Variables.getters).forEach(function (category) {
-    variableList = variableList.concat(
-      Blockly.Variables.allVariables(null, category)
-    );
-  })
   var newName = '';
   if (variableList.length) {
     variableList.sort(goog.string.caseInsensitiveCompare);

--- a/core/utils/variables.js
+++ b/core/utils/variables.js
@@ -195,6 +195,9 @@ Blockly.Variables.getGetter = function(blockSpace, category) {
   return (getterName && Blockly.Blocks[getterName]) ?
       new Blockly.Block(blockSpace, getterName) : null;
 };
+Blockly.Variables.registerGetter = function(category, blockName) {
+  Blockly.Variables.getters[category] = blockName;
+};
 
 Blockly.Variables.setters = {
   'Default': 'variables_set',
@@ -203,6 +206,9 @@ Blockly.Variables.getSetter = function(blockSpace, category) {
   var setterName = Blockly.Variables.setters[category];
   return (setterName && Blockly.Blocks[setterName]) ?
       new Blockly.Block(blockSpace, setterName) : null;
+};
+Blockly.Variables.registerSetter = function(category, blockName) {
+  Blockly.Variables.setters[category] = blockName;
 };
 
 /**

--- a/tests/blockly_test.html
+++ b/tests/blockly_test.html
@@ -25,5 +25,6 @@
     <script type="text/javascript" src="utils_test.js"></script>
     <script type="text/javascript" src="angle_helper_test.js"></script>
     <script type="text/javascript" src="fields_test.js"></script>
+    <script type="text/javascript" src="variables_test.js"></script>
   </body>
 </html>

--- a/tests/generators/unittest.js
+++ b/tests/generators/unittest.js
@@ -33,7 +33,7 @@ Blockly.Blocks.unittest_main = {
     this.setTooltip('Executes the enclosed unit tests,\n' +
                     'then prints a summary.');
   },
-  getVars: function() {
+  getVars: function(category) {
     return ['unittestResults'];
   }
 };
@@ -52,7 +52,7 @@ Blockly.Blocks.unittest_assertequals = {
         .appendTitle('expected');
     this.setTooltip('Tests that "actual == expected".');
   },
-  getVars: function() {
+  getVars: function(category) {
     return ['unittestResults'];
   }
 };
@@ -71,7 +71,7 @@ Blockly.Blocks.unittest_assertvalue = {
         [['true', 'TRUE'], ['false', 'FALSE'], ['null', 'NULL']]), 'EXPECTED');
     this.setTooltip('Tests that the value is true, false, or null.');
   },
-  getVars: function() {
+  getVars: function(category) {
     return ['unittestResults'];
   }
 };
@@ -87,7 +87,7 @@ Blockly.Blocks.unittest_fail = {
         .appendTitle('fail');
     this.setTooltip('Records an error.');
   },
-  getVars: function() {
+  getVars: function(category) {
     return ['unittestResults'];
   }
 };

--- a/tests/generators/unittest.js
+++ b/tests/generators/unittest.js
@@ -33,8 +33,10 @@ Blockly.Blocks.unittest_main = {
     this.setTooltip('Executes the enclosed unit tests,\n' +
                     'then prints a summary.');
   },
-  getVars: function(category) {
-    return ['unittestResults'];
+  getVars: function() {
+    return {
+      Default: ['unittestResults'],
+    };
   }
 };
 
@@ -52,8 +54,10 @@ Blockly.Blocks.unittest_assertequals = {
         .appendTitle('expected');
     this.setTooltip('Tests that "actual == expected".');
   },
-  getVars: function(category) {
-    return ['unittestResults'];
+  getVars: function() {
+    return {
+      Default: ['unittestResults'],
+    };
   }
 };
 
@@ -71,8 +75,10 @@ Blockly.Blocks.unittest_assertvalue = {
         [['true', 'TRUE'], ['false', 'FALSE'], ['null', 'NULL']]), 'EXPECTED');
     this.setTooltip('Tests that the value is true, false, or null.');
   },
-  getVars: function(category) {
-    return ['unittestResults'];
+  getVars: function() {
+    return {
+      Default: ['unittestResults'],
+    };
   }
 };
 
@@ -87,7 +93,9 @@ Blockly.Blocks.unittest_fail = {
         .appendTitle('fail');
     this.setTooltip('Records an error.');
   },
-  getVars: function(category) {
-    return ['unittestResults'];
+  getVars: function() {
+    return {
+      Default: ['unittestResults'],
+    };
   }
 };

--- a/tests/playground_requires.js
+++ b/tests/playground_requires.js
@@ -109,7 +109,10 @@ function createVariableSet(type, color) {
       this.setNextStatement(true);
       this.setTooltip(Blockly.Msg.VARIABLES_SET_TOOLTIP);
     },
-    getVars: function() {
+    getVars: function(category) {
+      if (category !== type) {
+        return [];
+      }
       return [this.getTitleValue('VAR')];
     },
     renameVar: function(oldName, newName) {

--- a/tests/playground_requires.js
+++ b/tests/playground_requires.js
@@ -109,11 +109,8 @@ function createVariableSet(type, color) {
       this.setNextStatement(true);
       this.setTooltip(Blockly.Msg.VARIABLES_SET_TOOLTIP);
     },
-    getVars: function(category) {
-      if (category && category !== type) {
-        return [];
-      }
-      return [this.getTitleValue('VAR')];
+    getVars: function() {
+      return Blockly.Variables.getVars.bind(this)(type);
     },
     renameVar: function(oldName, newName) {
       if (Blockly.Names.equals(oldName, this.getTitleValue('VAR'))) {

--- a/tests/playground_requires.js
+++ b/tests/playground_requires.js
@@ -110,7 +110,7 @@ function createVariableSet(type, color) {
       this.setTooltip(Blockly.Msg.VARIABLES_SET_TOOLTIP);
     },
     getVars: function(category) {
-      if (category !== type) {
+      if (category && category !== type) {
         return [];
       }
       return [this.getTitleValue('VAR')];

--- a/tests/variables_test.js
+++ b/tests/variables_test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+function setUp() {
+  Blockly.Blocks.string_variables_set = {
+    init: function () {
+      this.appendValueInput('VALUE')
+          .setStrictCheck(Blockly.BlockValueType.STRING)
+          .appendTitle(new Blockly.FieldVariable(Blockly.Msg.VARIABLES_SET_ITEM), 'VAR')
+      this.setPreviousStatement(true);
+      this.setNextStatement(true);
+    },
+    getVars: function (category) {
+      if (category && category !== Blockly.BlockValueType.STRING) {
+	return [];
+      }
+      return [this.getTitleValue('VAR')];
+    },
+  };
+  Blockly.valueTypeTabShapeMap = {'String': 'square'};
+}
+
+function tearDown() {
+  Blockly.Blocks.string_variables_set = Blockly.valueTypeTabShapeMap = undefined;
+}
+
+function test_allVariables() {
+  var container = Blockly.Test.initializeBlockSpaceEditor();
+
+  var blockXML = '<xml><block type="variables_get"><title name="VAR">i</title></block></xml>';
+  Blockly.Xml.domToBlockSpace(Blockly.mainBlockSpace, Blockly.Xml.textToDom(blockXML));
+  var variables = Blockly.Variables.allVariables();
+
+  assertEquals("One variable used", 1, variables.length);
+  assertEquals("Variable named 'i'", 'i', variables[0]);
+
+  goog.dom.removeNode(container);
+}
+
+function test_allVariablesCategorized() {
+  var container = Blockly.Test.initializeBlockSpaceEditor();
+
+  var blockXML = '<xml>' +
+    '<block type="variables_set"><title name="VAR">i</title></block>' +
+    '<block type="string_variables_set"><title name="VAR">j</title></block>' +
+  '</xml>';
+  Blockly.Xml.domToBlockSpace(Blockly.mainBlockSpace, Blockly.Xml.textToDom(blockXML));
+  var variables = Blockly.Variables.allVariables(null, Blockly.Variables.DEFAULT_CATEGORY);
+
+  assertEquals("One variable used", 1, variables.length);
+  assertEquals("Variable named 'i'", 'i', variables[0]);
+
+  goog.dom.removeNode(container);
+}
+
+function test_allVariablesOtherCategory() {
+  var container = Blockly.Test.initializeBlockSpaceEditor();
+  var blockXML = '<xml>' +
+    '<block type="variables_set"><title name="VAR">i</title></block>' +
+    '<block type="string_variables_set"><title name="VAR">j</title></block>' +
+  '</xml>';
+  Blockly.Xml.domToBlockSpace(Blockly.mainBlockSpace, Blockly.Xml.textToDom(blockXML));
+  var variables = Blockly.Variables.allVariables(null, 'String');
+
+  assertEquals("One variable used", 1, variables.length);
+  assertEquals("Variable named 'j'", 'j', variables[0]);
+
+  goog.dom.removeNode(container);
+}

--- a/tests/variables_test.js
+++ b/tests/variables_test.js
@@ -9,11 +9,10 @@ function setUp() {
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
-    getVars: function (category) {
-      if (category && category !== Blockly.BlockValueType.STRING) {
-	return [];
-      }
-      return [this.getTitleValue('VAR')];
+    getVars: function () {
+      return {
+        String: [this.getTitleValue('VAR')],
+      };
     },
   };
   Blockly.valueTypeTabShapeMap = {'String': 'square'};


### PR DESCRIPTION
In the process of creating the behavior editor, I've come across the need to create a toolbox category that autopopulates with a separate category of variable getter blocks (in particular for behaviors. but this is also useful for sprite and location variables). This PR enables that.

Basically, this PR modifies every blocks' `getVars` method to return a map of variables by category (usually there's just one category per block), so that the flyout creation code can find all the variables of a given category. All existing variables are now in the "Default" category, and https://github.com/code-dot-org/code-dot-org/pull/22233 puts the sprite variable getter/setter blocks into the "Sprite" category.