### PR TITLE
Make the function editor more flexible so that it can become a behavior editor

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -86,6 +86,9 @@ Blockly.Blocks.procedures_defnoreturn = {
     for (var x = 0; x < this.parameterNames_.length; x++) {
       var parameter = document.createElement('arg');
       parameter.setAttribute('name', this.parameterNames_[x]);
+      if (this.parameterTypes_) {
+        parameter.setAttribute('type', this.parameterTypes_[x]);
+      }
       container.appendChild(parameter);
     }
     // Add description mutation
@@ -102,6 +105,13 @@ Blockly.Blocks.procedures_defnoreturn = {
       var nodeName = childNode.nodeName.toLowerCase();
       if (nodeName === 'arg') {
         this.parameterNames_.push(childNode.getAttribute('name'));
+        var type = childNode.getAttribute('type');
+        if (type) {
+          if (!this.parameterTypes_) {
+            this.parameterTypes_ = [];
+          }
+          this.parameterTypes_[this.parameterNames_.length - 1] = type;
+        }
       } else if (nodeName === 'description') {
         this.description_ = childNode.textContent;
       }
@@ -217,6 +227,9 @@ Blockly.Blocks.procedures_defnoreturn = {
     var index = this.parameterNames_.indexOf(oldName);
     if (index > -1) {
       this.parameterNames_.splice(index, 1);
+      if (this.parameterTypes_) {
+        this.parameterTypes_.splice(index, 1);
+      }
       this.updateParams_();
     }
   },

--- a/blocks/variables.js
+++ b/blocks/variables.js
@@ -115,10 +115,12 @@ Blockly.Blocks.parameters_get = {
   },
   renameVar: function(oldName, newName) {
     // Params should only be used in the FunctionEditor but better to be safe
-    if (Blockly.functionEditor && Blockly.functionEditor.isOpen()) {
-      Blockly.functionEditor.renameParameter(oldName, newName);
-      Blockly.functionEditor.refreshParamsEverywhere();
-    }
+    Blockly.FunctionEditor.allFunctionEditors.forEach(function(functionEditor) {
+      if (functionEditor.isOpen()) {
+        functionEditor.renameParameter(oldName, newName);
+        functionEditor.refreshParamsEverywhere();
+      }
+    });
   },
   removeVar: Blockly.Blocks.variables_get.removeVar
 };

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -105,6 +105,18 @@ Blockly.Flyout = function(blockSpaceEditor, opt_static) {
 };
 
 /**
+ * Additional config for creating custom flyouts
+ * @type {string} type custom category for which to use the provided config
+ * @type {object} config
+ * @type {function} config.initialize
+ * @type {boolean} config.addDefaultVar
+ */
+Blockly.Flyout.configure = function (type, config) {
+  Blockly.Flyout.config[type] = config;
+}
+Blockly.Flyout.config = {};
+
+/**
  * Does the flyout automatically close when a block is created?
  * @type {boolean}
  */
@@ -478,10 +490,15 @@ Blockly.Flyout.prototype.show = function(xmlList) {
       function(procedureInfo) { return procedureInfo.isFunctionalVariable; }
     );
   } else if (goog.isString(firstBlock)) {
-    var addDefaultVar = true;
     // Special category for categorized variables.
     // Allow for a mix of static + dynamic blocks. Static blocks will appear
     // first in the category
+    var addDefaultVar = true;
+    var config = Blockly.Flyout.config[firstBlock];
+    if (config) {
+      addDefaultVar = config.addDefaultVar;
+      config.initialize(this, cursor);
+    }
     this.layoutXmlToBlocks_(xmlList.slice(1), blocks, gaps, margin);
     Blockly.Variables.flyoutCategory(
       blocks, gaps, margin, this.blockSpace_, firstBlock, addDefaultVar);

--- a/core/ui/function_editor.js
+++ b/core/ui/function_editor.js
@@ -83,6 +83,8 @@ Blockly.FunctionEditor = function(
   }
   this.parameterBlockTypes = opt_parameterBlockTypes || {};
   this.disableParamEditing = opt_disableParamEditing || false;
+
+  Blockly.FunctionEditor.allFunctionEditors.push(this);
 };
 
 Blockly.FunctionEditor.BLOCK_LAYOUT_LEFT_MARGIN = Blockly.BlockSpaceEditor.BUMP_PADDING_LEFT;
@@ -106,6 +108,9 @@ Blockly.FunctionEditor.RTL_CLOSE_BUTTON_OFFSET = 5;
 
 /** @type {number} */
 Blockly.FunctionEditor.BUTTON_TOP_OFFSET = -22;
+
+/** @type {Blockly.FunctionEditor[]} */
+Blockly.FunctionEditor.allFunctionEditors = [];
 
 /**
  * Get a string from Blockly.Msg, unless overridden by msgOverrides

--- a/core/ui/function_editor.js
+++ b/core/ui/function_editor.js
@@ -156,8 +156,8 @@ Blockly.FunctionEditor.prototype.openAndEditFunction = function(functionName) {
   this.populateParamToolbox_();
   this.setupUIAfterBlockInEditor_();
 
-  goog.dom.getElement('functionNameText').value = functionName;
-  goog.dom.getElement('functionDescriptionText').value =
+  this.container_.querySelector('#functionNameText').value = functionName;
+  this.container_.querySelector('#functionDescriptionText').value =
       this.functionDefinitionBlock.description_ || '';
   this.deleteButton_.setVisible(targetFunctionDefinitionBlock.userCreated);
 
@@ -220,8 +220,8 @@ Blockly.FunctionEditor.prototype.openWithNewFunction = function() {
 };
 
 Blockly.FunctionEditor.prototype.bindToolboxHandlers_ = function() {
-  var paramAddTextElement = goog.dom.getElement('paramAddText');
-  var paramAddButton = goog.dom.getElement('paramAddButton');
+  var paramAddTextElement = this.container_.querySelector('#paramAddText');
+  var paramAddButton = this.container_.querySelector('#paramAddButton');
   if (!Blockly.disableParamEditing) {
     Blockly.bindEvent_(paramAddButton, 'click', this,
         goog.bind(this.addParamFromInputField_, this, paramAddTextElement));
@@ -400,10 +400,10 @@ Blockly.FunctionEditor.prototype.hideAndRestoreBlocks_ = function() {
   this.functionDefinitionBlock = null;
   this.moveToMainBlockSpace_(functionDefinitionBlock);
 
-  goog.dom.getElement('functionNameText').value = '';
-  goog.dom.getElement('functionDescriptionText').value = '';
-  if (goog.dom.getElement('paramAddText')) {
-    goog.dom.getElement('paramAddText').value = '';
+  this.container_.querySelector('#functionNameText').value = '';
+  this.container_.querySelector('#functionDescriptionText').value = '';
+  if (this.container_.querySelector('#paramAddText')) {
+    this.container_.querySelector('#paramAddText').value = '';
   }
 
   goog.style.setElementShown(this.container_, false);
@@ -535,7 +535,7 @@ Blockly.FunctionEditor.prototype.create_ = function() {
 
   // The function editor block space passes clicks through via
   // pointer-events:none, so register the unselect handler on lower elements
-  Blockly.bindEvent_(goog.dom.getElement('modalContainer'), 'mousedown', this,
+  Blockly.bindEvent_(this.container_, 'mousedown', this,
       function(e) {
     // Only handle clicks on modalContainer, not a descendant
     if (e.target === e.currentTarget) {
@@ -553,19 +553,19 @@ Blockly.FunctionEditor.prototype.create_ = function() {
     }
   });
 
-  Blockly.bindEvent_(goog.dom.getElement('modalEditorClose'), 'mousedown', this,
+  Blockly.bindEvent_(this.container_.querySelector('#modalEditorClose'), 'mousedown', this,
       this.onClose);
-  Blockly.bindEvent_(goog.dom.getElement('functionNameText'), 'input', this,
+  Blockly.bindEvent_(this.container_.querySelector('#functionNameText'), 'input', this,
       functionNameChange);
   // IE9 doesn't fire oninput when delete key is pressed, bind keydown also
-  Blockly.bindEvent_(goog.dom.getElement('functionNameText'), 'keydown', this,
+  Blockly.bindEvent_(this.container_.querySelector('#functionNameText'), 'keydown', this,
       functionNameChange);
   function functionNameChange(e) {
     var value = e.target.value;
     var disallowedCharacters = /\)|\(/g;
     if (disallowedCharacters.test(value)) {
       value = value.replace(disallowedCharacters, '');
-      goog.dom.getElement('functionNameText').value = value;
+      this.container_.querySelector('#functionNameText').value = value;
     }
     this.functionDefinitionBlock.setTitleValue(value, 'NAME');
   }
@@ -576,10 +576,10 @@ Blockly.FunctionEditor.prototype.create_ = function() {
     }
   });
 
-  Blockly.bindEvent_(goog.dom.getElement('functionDescriptionText'), 'input',
+  Blockly.bindEvent_(this.container_.querySelector('#functionDescriptionText'), 'input',
       this, functionDescriptionChange);
   // IE9 doesn't fire oninput when delete key is pressed, bind keydown also
-  Blockly.bindEvent_(goog.dom.getElement('functionDescriptionText'), 'keydown',
+  Blockly.bindEvent_(this.container_.querySelector('#functionDescriptionText'), 'keydown',
       this, functionDescriptionChange);
   function functionDescriptionChange(e) {
     this.functionDefinitionBlock.description_ = e.target.value;
@@ -892,7 +892,7 @@ Blockly.FunctionEditor.prototype.createParameterEditor_ = function() {
     return;
   }
 
-  goog.dom.getElement('paramEditingArea').innerHTML =
+  this.container_.querySelector('#paramEditingArea').innerHTML =
     '<div>' + Blockly.Msg.FUNCTION_PARAMETERS_LABEL + '</div>'
     + '<div>'
     + '<input id="paramAddText" type="text" style="width: 200px;"/> '

--- a/core/ui/function_editor.js
+++ b/core/ui/function_editor.js
@@ -23,7 +23,8 @@ goog.require('goog.structs.LinkedMap');
 Blockly.FunctionEditor = function(
     opt_msgOverrides,
     opt_definitionBlockType,
-    opt_parameterBlockTypes) {
+    opt_parameterBlockTypes,
+    opt_disableParamEditing) {
   /**
    * Whether this editor has been initialized
    * @type {boolean}
@@ -81,6 +82,7 @@ Blockly.FunctionEditor = function(
     this.definitionBlockType = opt_definitionBlockType;
   }
   this.parameterBlockTypes = opt_parameterBlockTypes || {};
+  this.disableParamEditing = opt_disableParamEditing || false;
 };
 
 Blockly.FunctionEditor.BLOCK_LAYOUT_LEFT_MARGIN = Blockly.BlockSpaceEditor.BUMP_PADDING_LEFT;
@@ -110,6 +112,10 @@ Blockly.FunctionEditor.BUTTON_TOP_OFFSET = -22;
  */
 Blockly.FunctionEditor.prototype.getMsg = function(label) {
   return this.msgOverrides_[label] || Blockly.Msg[label];
+};
+
+Blockly.FunctionEditor.prototype.paramEditingDisabled = function () {
+  return Blockly.disableParamEditing || this.disableParamEditing;
 };
 
 /**
@@ -249,7 +255,7 @@ Blockly.FunctionEditor.prototype.openWithNewFunction = function() {
 Blockly.FunctionEditor.prototype.bindToolboxHandlers_ = function() {
   var paramAddTextElement = this.container_.querySelector('#paramAddText');
   var paramAddButton = this.container_.querySelector('#paramAddButton');
-  if (!Blockly.disableParamEditing) {
+  if (!this.paramEditingDisabled()) {
     Blockly.bindEvent_(paramAddButton, 'click', this,
         goog.bind(this.addParamFromInputField_, this, paramAddTextElement));
     Blockly.bindEvent_(paramAddTextElement, 'keydown', this, function(e) {
@@ -920,7 +926,7 @@ Blockly.FunctionEditor.prototype.getContractDomTopY_ = function() {
 };
 
 Blockly.FunctionEditor.prototype.createParameterEditor_ = function() {
-  if (Blockly.disableParamEditing) {
+  if (this.paramEditingDisabled()) {
     return;
   }
 

--- a/core/ui/function_editor.js
+++ b/core/ui/function_editor.js
@@ -20,7 +20,7 @@ goog.require('goog.structs.LinkedMap');
  * Class for a modal function editor.
  * @constructor
  */
-Blockly.FunctionEditor = function() {
+Blockly.FunctionEditor = function(opt_msgOverrides) {
   /**
    * Whether this editor has been initialized
    * @type {boolean}
@@ -72,6 +72,8 @@ Blockly.FunctionEditor = function() {
 
   /** @type {BlockSpace} */
   this.modalBlockSpace = null;
+
+  this.msgOverrides_ = opt_msgOverrides || {};
 };
 
 Blockly.FunctionEditor.BLOCK_LAYOUT_LEFT_MARGIN = Blockly.BlockSpaceEditor.BUMP_PADDING_LEFT;
@@ -95,6 +97,13 @@ Blockly.FunctionEditor.RTL_CLOSE_BUTTON_OFFSET = 5;
 
 /** @type {number} */
 Blockly.FunctionEditor.BUTTON_TOP_OFFSET = -22;
+
+/**
+ * Get a string from Blockly.Msg, unless overridden by msgOverrides
+ */
+Blockly.FunctionEditor.prototype.getMsg = function(label) {
+  return this.msgOverrides_[label] || Blockly.Msg[label];
+};
 
 /**
  * The type of block to instantiate in the function editing area
@@ -782,7 +791,7 @@ Blockly.FunctionEditor.prototype.addCloseButton_ = function () {
     'y': padding,
     'class': 'blocklyText'
   }, this.closeButton_);
-  text.textContent = Blockly.Msg.CLOSE;
+  text.textContent = this.getMsg('CLOSE');
   this.modalBlockSpaceEditor.appendSVGChild(this.closeButton_);
   var bounds = text.getBoundingClientRect();
   r.setAttribute('width', bounds.width + 2 * padding);
@@ -797,18 +806,18 @@ Blockly.FunctionEditor.prototype.addCloseButton_ = function () {
  */
 Blockly.FunctionEditor.prototype.addDeleteButton_ = function () {
   this.deleteButton_ = new Blockly.SvgTextButton(
-      this.modalBlockSpaceEditor.getSVGElement(), Blockly.Msg.DELETE,
+      this.modalBlockSpaceEditor.getSVGElement(), this.getMsg('DELETE'),
       this.onDeletePressed.bind(this));
 };
 
 Blockly.FunctionEditor.prototype.onDeletePressed = function () {
   var functionName = this.functionDefinitionBlock.getProcedureInfo().name;
-  var deleteMessage = Blockly.Msg.CONFIRM_DELETE_FUNCTION_MESSAGE.replace('%1',
+  var deleteMessage = this.getMsg('CONFIRM_DELETE_FUNCTION_MESSAGE').replace('%1',
       functionName);
   Blockly.showSimpleDialog({
     bodyText: deleteMessage,
-    cancelText: Blockly.Msg.DELETE,
-    confirmText: Blockly.Msg.KEEP,
+    cancelText: this.getMsg('DELETE'),
+    confirmText: this.getMsg('KEEP'),
     onConfirm: null,
     onCancel: this.onDeleteConfirmed.bind(this, functionName),
     cancelButtonClass: 'red-delete-button'
@@ -860,7 +869,7 @@ Blockly.FunctionEditor.prototype.addEditorFrame_ = function () {
     'class': 'blocklyText',
     style: 'font-size: 12pt'
   }, this.modalBackground_);
-  this.frameText_.textContent = Blockly.Msg.FUNCTION_HEADER;
+  this.frameText_.textContent = this.getMsg('FUNCTION_HEADER');
 };
 
 Blockly.FunctionEditor.prototype.position_ = function() {
@@ -893,10 +902,10 @@ Blockly.FunctionEditor.prototype.createParameterEditor_ = function() {
   }
 
   this.container_.querySelector('#paramEditingArea').innerHTML =
-    '<div>' + Blockly.Msg.FUNCTION_PARAMETERS_LABEL + '</div>'
+    '<div>' + this.getMsg('FUNCTION_PARAMETERS_LABEL') + '</div>'
     + '<div>'
     + '<input id="paramAddText" type="text" style="width: 200px;"/> '
-    + '<button id="paramAddButton" class="btn no-mc">' + Blockly.Msg.ADD_PARAMETER + '</button>'
+    + '<button id="paramAddButton" class="btn no-mc">' + this.getMsg('ADD_PARAMETER') + '</button>'
     + '</div>';
 };
 
@@ -915,9 +924,9 @@ Blockly.FunctionEditor.prototype.createContractDom_ = function() {
     this.contractDiv_.setAttribute('dir', 'RTL');
   }
   this.contractDiv_.innerHTML =
-      '<div>' + Blockly.Msg.FUNCTION_NAME_LABEL + '</div>'
+      '<div>' + this.getMsg('FUNCTION_NAME_LABEL') + '</div>'
       + '<div><input id="functionNameText" type="text"></div>'
-      + '<div>' + Blockly.Msg.FUNCTION_DESCRIPTION_LABEL + '</div>'
+      + '<div>' + this.getMsg('FUNCTION_DESCRIPTION_LABEL') + '</div>'
       + '<div><textarea id="functionDescriptionText" rows="2"></textarea></div>'
       + '<div style="margin: 0;" id="paramEditingArea"></div>';
   this.contractDiv_.style.display = 'block';

--- a/core/utils/variables.js
+++ b/core/utils/variables.js
@@ -140,10 +140,12 @@ Blockly.Variables.renameVariable = function(oldName, newName, blockSpace) {
     }
   }
 
-  if (Blockly.functionEditor && Blockly.functionEditor.isOpen()) {
-    Blockly.functionEditor.renameParameter(oldName, newName);
-    Blockly.functionEditor.refreshParamsEverywhere();
-  }
+  Blockly.FunctionEditor.allFunctionEditors.forEach(function (functionEditor) {
+    if (functionEditor.isOpen()) {
+      functionEditor.renameParameter(oldName, newName);
+      functionEditor.refreshParamsEverywhere();
+    }
+  });
 };
 
 /**
@@ -162,10 +164,12 @@ Blockly.Variables.deleteVariable = function(nameToRemove, blockSpace) {
     }
   }
   // Notify the modal workspace to remove the parameter from its flyout
-  if (Blockly.functionEditor && Blockly.functionEditor.isOpen()) {
-    Blockly.functionEditor.removeParameter(nameToRemove);
-    Blockly.functionEditor.refreshParamsEverywhere();
-  }
+  Blockly.FunctionEditor.allFunctionEditors.forEach(function (functionEditor) {
+    if (functionEditor.isOpen()) {
+      functionEditor.removeParameter(nameToRemove);
+      functionEditor.refreshParamsEverywhere();
+    }
+  });
 };
 
 /**

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -21,6 +21,7 @@ function start() {
   goog.tweak.registerBoolean('openContractEditor', 'pre-opens contract editor', false);
   goog.tweak.registerBoolean('toggleScrollDragDebug', 'enables autoscroll debugging', false);
   goog.tweak.registerBoolean('openFunctionEditor', 'pre-opens function editor', false);
+  goog.tweak.registerBoolean('openCustomizedFunctionEditor', 'pre-opens customized function editor', false);
   goog.tweak.registerBoolean('enableExampleRunning', 'enables running of examples', false);
   goog.tweak.registerBoolean('typeHints', 'glow typed inputs based on what color of block they expect', false);
   goog.tweak.registerNumber('addContractDomains', 'adds a given number of domain parameters to the auto-opened contract editor', 0);
@@ -48,6 +49,8 @@ function start() {
     newContractEditor();
   } else if (goog.tweak.getBoolean('openFunctionEditor')) {
     newFunctionEditor();
+  } else if (goog.tweak.getBoolean('openCustomizedFunctionEditor')) {
+    newCustomizedFunctionEditor();
   }
   if (goog.tweak.getBoolean('toggleScrollDragDebug')) {
     Blockly.ScrollOnBlockDragHandler.DEBUG = true;
@@ -113,6 +116,20 @@ function newFunctionEditor() {
   Blockly.functionEditor = new Blockly.FunctionEditor({
   });
   Blockly.functionEditor.openWithNewFunction();
+}
+
+function newCustomizedFunctionEditor() {
+  Blockly.oceanBoilerEditor = new Blockly.FunctionEditor(
+    {
+      FUNCTION_HEADER: 'Ocean Boiler',
+      FUNCTION_NAME_LABEL: 'Name your ocean boiler:',
+      FUNCTION_DESCRIPTION_LABEL: 'What kind of ocean is this supposed to boil?',
+    },
+    'ocean_boiler_definition',
+    null,
+    true,
+  );
+  Blockly.oceanBoilerEditor.openWithNewFunction();
 }
 
 function toXml() {

--- a/tests/playground_requires.js
+++ b/tests/playground_requires.js
@@ -152,3 +152,18 @@ Blockly.Blocks.button_block = {
     this.setOutput(true, Blockly.BlockValueType.STRING);
   },
 };
+
+Blockly.Blocks.ocean_boiler_definition = Object.assign({},
+  Blockly.Blocks.procedures_defnoreturn,
+  {
+    init: function() {
+      Blockly.Blocks.procedures_defnoreturn.init.bind(this)();
+      this.appendDummyInput()
+          .appendTitle(new Blockly.FieldLabel('this is a different definition block'));
+      this.setInputsInline(false);
+      this.setHSV(20, 0.5, 0.5);
+    },
+  }
+);
+Blockly.Procedures.DEFINITION_BLOCK_TYPES.push('ocean_boiler_definition');
+


### PR DESCRIPTION
Adds a few options to the function editor so that, with the right constructor arguments, it can be a behavior editor instead.
* `msgOverrides` a map a of strings to replace various UI strings, e.g. replacing "Function" with "Behavior"
* `definitionBlockType` which block type to use for function definitions. Defaults to `procedures_defnoreturn`
* `opt_parameterBlockTypes` a map of block value types to the corresponding parameter blocks
* `opt_disableParamEditing` disables param editing for just this function editor, rather than globally.

See https://github.com/code-dot-org/code-dot-org/pull/22307/files#diff-3c5e6748726d3411afe8256d6ac20a3eR463 for how I intend to use these new options.