### PR TITLE
Ignore duplicate touch events

### DIFF
--- a/core/ui/block_space/toolbox.js
+++ b/core/ui/block_space/toolbox.js
@@ -269,15 +269,7 @@ Blockly.Toolbox.TreeControl.prototype.enterDocument = function() {
       'onpointerdown' in window ||
       'onmspointerdown' in window) {
     var el = this.getElement();
-    var debouncedHandler =
-      goog.functions.debounce(this.handleTouchEvent_, 50, this);
-    var handler = (function (e) {
-      if (this.getNodeFromEvent_(e)) {
-        e.preventDefault();
-        e.stopImmediatePropagation();
-        debouncedHandler(e);
-      }
-    }).bind(this);
+    var handler = goog.functions.rateLimit(this.handleTouchEvent_, 50, this);
     Blockly.bindEvent_(el, goog.events.EventType.TOUCHSTART, this, handler);
     Blockly.bindEvent_(el, goog.events.EventType.POINTERDOWN, this, handler);
     Blockly.bindEvent_(el, goog.events.EventType.MSPOINTERDOWN, this, handler);
@@ -289,12 +281,14 @@ Blockly.Toolbox.TreeControl.prototype.enterDocument = function() {
  * @private
  */
 Blockly.Toolbox.TreeControl.prototype.handleTouchEvent_ = function(e) {
+  e.preventDefault();
   var node = this.getNodeFromEvent_(e);
   if (node && (e.type === goog.events.EventType.TOUCHSTART ||
                e.type === goog.events.EventType.POINTERDOWN ||
                e.type === goog.events.EventType.MSPOINTERDOWN)) {
     // Fire asynchronously since onMouseDown takes long enough that the browser
     // would fire the default mouse event before this method returns.
+    e.stopImmediatePropagation();
     window.setTimeout(function() {
       node.onMouseDown(e);  // Same behavior for click and touch.
     }, 1);

--- a/core/ui/block_space/toolbox.js
+++ b/core/ui/block_space/toolbox.js
@@ -291,6 +291,11 @@ Blockly.Toolbox.TreeControl.prototype.handleTouchEvent_ = function(e) {
     // Fire asynchronously since onMouseDown takes long enough that the browser
     // would fire the default mouse event before this method returns.
     e.stopImmediatePropagation();
+    if (this.previousTouchEventTimeStamp === e.timeStamp) {
+      // This is a duplicate touch/pointer event, ignore it
+      return;
+    }
+    this.previousTouchEventTimeStamp = e.timeStamp;
     window.setTimeout(function() {
       node.onMouseDown(e);  // Same behavior for click and touch.
     }, 1);

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   "devDependencies": {
     "phantomjs-prebuilt": "~2.1.3",
     "google-closure-compiler": "~20170218.0.0",
-    "google-closure-library": "~20160911.0.0"
+    "google-closure-library": "~20170124.0.0"
   }
 }


### PR DESCRIPTION
There's some special touch event handling code here that makes the toolbox more responsive than simply relying on simulated mouse events. Unfortunately chrome is giving us two touch events (so it closes the toolbox category immediately after you open it), so I'm adding a check to ignore duplicated touch events.