### PR TITLE
The 'STACK' of a functional_definition is the implicit return value

### DIFF
--- a/generators/javascript/functional_procedures.js
+++ b/generators/javascript/functional_procedures.js
@@ -41,13 +41,13 @@ Blockly.JavaScript.functional_definition = function() {
         Blockly.Variables.NAME_TYPE,
         Blockly.Variables.NAME_TYPE_LOCAL);
   }
-  var branch = Blockly.JavaScript.statementToCode(this, 'STACK');
+  var branch = '';
 
   if (Blockly.JavaScript.INFINITE_LOOP_TRAP) {
     branch = Blockly.JavaScript.INFINITE_LOOP_TRAP.replace(/%1/g,
         '\'' + this.id + '\'') + branch;
   }
-  var returnValue = Blockly.JavaScript.statementToCode(this, 'RETURN',
+  var returnValue = Blockly.JavaScript.statementToCode(this, 'STACK',
       Blockly.JavaScript.ORDER_NONE) || '';
   if (returnValue) {
     returnValue = '  return ' + returnValue + ';\n';
@@ -55,7 +55,7 @@ Blockly.JavaScript.functional_definition = function() {
   var code = (Blockly.varsInGlobals ?
                 'Globals.' + funcName + ' = function' :
                 'function ' + funcName) +
-             '(' + args.join(', ') + ') {\nreturn ' + branch + returnValue + '\n}';
+             '(' + args.join(', ') + ') {\n' + branch + returnValue + '\n}';
   code = Blockly.JavaScript.scrub_(this, code);
   Blockly.JavaScript.definitions_[funcName] = code;
   return null;


### PR DESCRIPTION
Regular `procedures_defreturn` functions have an explicit return connection:

https://github.com/code-dot-org/blockly/blob/d18d42d5ed6404dc64e8f461650245c2c6a91f47/blocks/procedures.js#L301

![image](https://user-images.githubusercontent.com/413693/40204270-cd06e3f0-59dc-11e8-987b-0c7b6e4241f6.png)

But for `functional_definition` the 'STACK' connection is always the implicit return value.

Fixes https://github.com/code-dot-org/code-dot-org/pull/22463#issuecomment-390008959.