### PR TITLE
Fix square and rounded tabs for tall blocks

### DIFF
--- a/core/ui/block_svg/block_svg.js
+++ b/core/ui/block_svg/block_svg.js
@@ -333,13 +333,13 @@ BS.SQUARE_TAB_PATH_DOWN_HIGHLIGHT_RTL =
  * @const
  */
 BS.SQUARE_TAB_PATH_UP =
-  'v -8 ' +
+  'V 17 ' +
   'h ' + (BS.TAB_WIDTH * -1) + ' ' +
   'v -10 ' +
   'h ' + BS.TAB_WIDTH;
 
 BS.SQUARE_TAB_PATH_UP_HIGHLIGHT =
-  'v -7 ' +
+  'V 18 ' +
   'm ' + (BS.TAB_WIDTH * -1) + ' -1.5 ' +
   'v -9 ' +
   'h ' + BS.TAB_WIDTH + ' ' +
@@ -375,12 +375,12 @@ BS.ROUNDED_TAB_PATH_DOWN_HIGHLIGHT_RTL =
  * @const
  */
 BS.ROUNDED_TAB_PATH_UP =
-  'v -6 ' +
+  'V 19 ' +
   'c ' + (BS.TAB_WIDTH * -0.5) + ' 0, ' + (BS.TAB_WIDTH * -1) + ' 0, ' + (BS.TAB_WIDTH * -1) + ' -6 ' +
   'c 0 -6, ' + (BS.TAB_WIDTH * 0.5) + ' -6, ' + BS.TAB_WIDTH + ' -6 ';
 
 BS.ROUNDED_TAB_PATH_UP_HIGHLIGHT =
-  'v -5.5 ' +
+  'V 19.5 ' +
   'm -6 -2 ' +
   'c -1 -1, -2 -2, -2 -4.5 ' +
   'c 0 -6, ' + (BS.TAB_WIDTH * 0.5) + ' -6, ' + BS.TAB_WIDTH + ' -6 ' +


### PR DESCRIPTION
Angled tabs were already correct (using `V` instead of relative `v`).

![screen shot 2018-05-18 at 5 19 49 pm](https://user-images.githubusercontent.com/413693/40262840-fa117c28-5abf-11e8-9430-e208b9ed448c.png)

![screen shot 2018-05-18 at 5 20 34 pm](https://user-images.githubusercontent.com/413693/40262844-fcaa20c0-5abf-11e8-9296-f75d2e4a6746.png)