### PR TITLE
Type hints should be below the blocklyPathDark shadow

### DIFF
--- a/core/ui/block_svg/block_svg.js
+++ b/core/ui/block_svg/block_svg.js
@@ -64,11 +64,6 @@ Blockly.BlockSvg = function(block) {
 };
 
 Blockly.BlockSvg.prototype.initChildren = function () {
-  this.svgPathDark_ = Blockly.createSvgElement('path', {
-    'class': 'blocklyPathDark',
-    'transform': 'translate(1, 1)',
-    'fill-rule': 'evenodd'
-  }, this.svgGroup_);
   if (Blockly.typeHints) {
     this.svgTypeHints_ = Blockly.createSvgElement('g', {
       'class': 'blocklyTypeHint'
@@ -79,6 +74,11 @@ Blockly.BlockSvg.prototype.initChildren = function () {
       }, this.svgTypeHints_);
     }
   }
+  this.svgPathDark_ = Blockly.createSvgElement('path', {
+    'class': 'blocklyPathDark',
+    'transform': 'translate(1, 1)',
+    'fill-rule': 'evenodd'
+  }, this.svgGroup_);
   this.svgPath_ = Blockly.createSvgElement('path', {
     'class': 'blocklyPath',
     'fill-rule': 'evenodd'


### PR DESCRIPTION
Follow up to PR https://github.com/code-dot-org/blockly/pull/100.  Better definition for type hints where the hint is the same color as the block.

Before:

![screen shot 2018-05-21 at 10 37 34 am](https://user-images.githubusercontent.com/413693/40321190-17fb34b6-5ce3-11e8-8043-abd6717e0db2.png)

After:

![screen shot 2018-05-21 at 10 37 06 am](https://user-images.githubusercontent.com/413693/40321185-138ca5b8-5ce3-11e8-8be2-b5893597af5b.png)