### PR TITLE
Use output type to set default block color, when no color is specified

### DIFF
--- a/blocks/colour.js
+++ b/blocks/colour.js
@@ -32,7 +32,6 @@ Blockly.Blocks.colour_picker = {
   // Colour picker.
   init: function() {
     this.setHelpUrl(Blockly.Msg.COLOUR_PICKER_HELPURL);
-    this.setHSV(196, 1.0, 0.79);
     this.appendDummyInput()
         .appendTitle(new Blockly.FieldColour('#ff0000'), 'COLOUR');
     this.setOutput(true, Blockly.BlockValueType.COLOUR);
@@ -44,7 +43,6 @@ Blockly.Blocks.colour_random = {
   // Random colour.
   init: function() {
     this.setHelpUrl(Blockly.Msg.COLOUR_RANDOM_HELPURL);
-    this.setHSV(196, 1.0, 0.79);
     this.appendDummyInput()
         .appendTitle(Blockly.Msg.COLOUR_RANDOM_TITLE);
     this.setOutput(true, Blockly.BlockValueType.COLOUR);
@@ -56,7 +54,6 @@ Blockly.Blocks.colour_rgb = {
   // Compose a colour from RGB components.
   init: function() {
     this.setHelpUrl(Blockly.Msg.COLOUR_RGB_HELPURL);
-    this.setHSV(196, 1.0, 0.79);
     this.appendValueInput('RED')
         .setCheck(Blockly.BlockValueType.NUMBER)
         .setAlign(Blockly.ALIGN_RIGHT)
@@ -79,7 +76,6 @@ Blockly.Blocks.colour_blend = {
   // Blend two colours together.
   init: function() {
     this.setHelpUrl(Blockly.Msg.COLOUR_BLEND_HELPURL);
-    this.setHSV(42, 0.89, 0.99);
     this.appendValueInput('COLOUR1')
         .setCheck(Blockly.BlockValueType.COLOUR)
         .setAlign(Blockly.ALIGN_RIGHT)

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -32,7 +32,6 @@ Blockly.Blocks.lists_create_empty = {
   // Create an empty list.
   init: function() {
     this.setHelpUrl(Blockly.Msg.LISTS_CREATE_EMPTY_HELPURL);
-    this.setHSV(40, 1.0, 0.99);
     this.setOutput(true, Blockly.BlockValueType.ARRAY);
     this.appendDummyInput()
         .appendTitle(Blockly.Msg.LISTS_CREATE_EMPTY_TITLE);
@@ -43,7 +42,6 @@ Blockly.Blocks.lists_create_empty = {
 Blockly.Blocks.lists_create_with = {
   // Create a list with any number of elements of any type.
   init: function() {
-    this.setHSV(40, 1.0, 0.99);
     this.appendValueInput('ADD0')
         .appendTitle(Blockly.Msg.LISTS_CREATE_WITH_INPUT_WITH);
     this.appendValueInput('ADD1');
@@ -160,7 +158,6 @@ Blockly.Blocks.lists_repeat = {
   // Create a list with one element repeated.
   init: function() {
     this.setHelpUrl(Blockly.Msg.LISTS_REPEAT_HELPURL);
-    this.setHSV(40, 1.0, 0.99);
     this.setOutput(true, Blockly.BlockValueType.ARRAY);
     this.interpolateMsg(Blockly.Msg.LISTS_REPEAT_TITLE,
                         ['ITEM', null, Blockly.ALIGN_RIGHT],
@@ -424,7 +421,6 @@ Blockly.Blocks.lists_getSublist = {
          [Blockly.Msg.LISTS_GET_INDEX_FROM_END, 'FROM_END'],
          [Blockly.Msg.LISTS_GET_INDEX_LAST, 'LAST']];
     this.setHelpUrl(Blockly.Msg.LISTS_GET_SUBLIST_HELPURL);
-    this.setHSV(40, 1.0, 0.99);
     this.appendValueInput('LIST')
         .setCheck(Blockly.BlockValueType.ARRAY)
         .appendTitle(Blockly.Msg.LISTS_GET_SUBLIST_INPUT_IN_LIST);

--- a/blocks/logic.js
+++ b/blocks/logic.js
@@ -244,7 +244,6 @@ Blockly.Blocks.logic_compare = {
       ];
     }
     this.setHelpUrl(Blockly.Msg.LOGIC_COMPARE_HELPURL);
-    this.setHSV(196, 1.0, 0.79);
     this.setOutput(true, Blockly.BlockValueType.BOOLEAN);
     this.appendValueInput('A');
     this.appendValueInput('B')
@@ -274,7 +273,6 @@ Blockly.Blocks.logic_operation = {
         [[Blockly.Msg.LOGIC_OPERATION_AND, 'AND'],
          [Blockly.Msg.LOGIC_OPERATION_OR, 'OR']];
     this.setHelpUrl(Blockly.Msg.LOGIC_OPERATION_HELPURL);
-    this.setHSV(196, 1.0, 0.79);
     this.setOutput(true, Blockly.BlockValueType.BOOLEAN);
     this.appendValueInput('A')
         .setCheck(Blockly.BlockValueType.BOOLEAN);
@@ -300,7 +298,6 @@ Blockly.Blocks.logic_negate = {
   // Negation.
   init: function() {
     this.setHelpUrl(Blockly.Msg.LOGIC_NEGATE_HELPURL);
-    this.setHSV(196, 1.0, 0.79);
     this.setOutput(true, Blockly.BlockValueType.BOOLEAN);
     this.interpolateMsg(Blockly.Msg.LOGIC_NEGATE_TITLE,
                         ['BOOL', Blockly.BlockValueType.BOOLEAN, Blockly.ALIGN_RIGHT],
@@ -316,7 +313,6 @@ Blockly.Blocks.logic_boolean = {
         [[Blockly.Msg.LOGIC_BOOLEAN_TRUE, 'TRUE'],
          [Blockly.Msg.LOGIC_BOOLEAN_FALSE, 'FALSE']];
     this.setHelpUrl(Blockly.Msg.LOGIC_BOOLEAN_HELPURL);
-    this.setHSV(196, 1.0, 0.79);
     this.setOutput(true, Blockly.BlockValueType.BOOLEAN);
     this.appendDummyInput()
         .appendTitle(new Blockly.FieldDropdown(BOOLEANS), 'BOOL');

--- a/blocks/math.js
+++ b/blocks/math.js
@@ -32,7 +32,6 @@ Blockly.Blocks.math_number = {
   // Numeric value.
   init: function() {
     this.setHelpUrl(Blockly.Msg.MATH_NUMBER_HELPURL);
-    this.setHSV(258, 0.35, 0.62);
     this.appendDummyInput()
         .appendTitle(new Blockly.FieldTextInput('0',
         Blockly.FieldTextInput.numberValidator), 'NUM');
@@ -51,7 +50,6 @@ Blockly.Blocks.math_arithmetic = {
          [Blockly.Msg.MATH_DIVISION_SYMBOL, 'DIVIDE'],
          [Blockly.Msg.MATH_POWER_SYMBOL, 'POWER']];
     this.setHelpUrl(Blockly.Msg.MATH_ARITHMETIC_HELPURL);
-    this.setHSV(258, 0.35, 0.62);
     this.setOutput(true, Blockly.BlockValueType.NUMBER);
     this.appendValueInput('A')
         .setCheck(Blockly.BlockValueType.NUMBER);
@@ -87,7 +85,6 @@ Blockly.Blocks.math_single = {
          ['e^', 'EXP'],
          ['10^', 'POW10']];
     this.setHelpUrl(Blockly.Msg.MATH_SINGLE_HELPURL);
-    this.setHSV(258, 0.35, 0.62);
     this.setOutput(true, Blockly.BlockValueType.NUMBER);
     this.appendValueInput('NUM')
         .setCheck(Blockly.BlockValueType.NUMBER)
@@ -121,7 +118,6 @@ Blockly.Blocks.math_trig = {
          [Blockly.Msg.MATH_TRIG_ACOS, 'ACOS'],
          [Blockly.Msg.MATH_TRIG_ATAN, 'ATAN']];
     this.setHelpUrl(Blockly.Msg.MATH_TRIG_HELPURL);
-    this.setHSV(258, 0.35, 0.62);
     this.setOutput(true, Blockly.BlockValueType.NUMBER);
     this.appendValueInput('NUM')
         .setCheck(Blockly.BlockValueType.NUMBER)
@@ -154,7 +150,6 @@ Blockly.Blocks.math_constant = {
          ['sqrt(\u00bd)', 'SQRT1_2'],
          ['\u221e', 'INFINITY']];
     this.setHelpUrl(Blockly.Msg.MATH_CONSTANT_HELPURL);
-    this.setHSV(258, 0.35, 0.62);
     this.setOutput(true, Blockly.BlockValueType.NUMBER);
     this.appendDummyInput()
         .appendTitle(new Blockly.FieldDropdown(CONSTANTS), 'CONSTANT');
@@ -174,7 +169,6 @@ Blockly.Blocks.math_number_property = {
          [Blockly.Msg.MATH_IS_POSITIVE, 'POSITIVE'],
          [Blockly.Msg.MATH_IS_NEGATIVE, 'NEGATIVE'],
          [Blockly.Msg.MATH_IS_DIVISIBLE_BY, 'DIVISIBLE_BY']];
-    this.setHSV(258, 0.35, 0.62);
     this.appendValueInput('NUMBER_TO_CHECK')
         .setCheck(Blockly.BlockValueType.NUMBER);
     var dropdown = new Blockly.FieldDropdown(PROPERTIES, function(option) {
@@ -249,7 +243,6 @@ Blockly.Blocks.math_round = {
          [Blockly.Msg.MATH_ROUND_OPERATOR_ROUNDUP, 'ROUNDUP'],
          [Blockly.Msg.MATH_ROUND_OPERATOR_ROUNDDOWN, 'ROUNDDOWN']];
     this.setHelpUrl(Blockly.Msg.MATH_ROUND_HELPURL);
-    this.setHSV(258, 0.35, 0.62);
     this.setOutput(true, Blockly.BlockValueType.NUMBER);
     this.appendValueInput('NUM')
         .setCheck(Blockly.BlockValueType.NUMBER)
@@ -274,7 +267,6 @@ Blockly.Blocks.math_on_list = {
     // Assign 'this' to a variable for use in the closure below.
     var thisBlock = this;
     this.setHelpUrl(Blockly.Msg.MATH_ONLIST_HELPURL);
-    this.setHSV(258, 0.35, 0.62);
     this.setOutput(true, Blockly.BlockValueType.NUMBER);
     var dropdown = new Blockly.FieldDropdown(OPERATORS, function(newOp) {
       if (newOp == 'MODE') {
@@ -307,7 +299,6 @@ Blockly.Blocks.math_modulo = {
   // Remainder of a division.
   init: function() {
     this.setHelpUrl(Blockly.Msg.MATH_MODULO_HELPURL);
-    this.setHSV(258, 0.35, 0.62);
     this.setOutput(true, Blockly.BlockValueType.NUMBER);
     this.interpolateMsg(Blockly.Msg.MATH_MODULO_TITLE,
                         ['DIVIDEND', 'Number', Blockly.ALIGN_RIGHT],
@@ -322,7 +313,6 @@ Blockly.Blocks.math_constrain = {
   // Constrain a number between two limits.
   init: function() {
     this.setHelpUrl(Blockly.Msg.MATH_CONSTRAIN_HELPURL);
-    this.setHSV(258, 0.35, 0.62);
     this.setOutput(true, Blockly.BlockValueType.NUMBER);
     this.interpolateMsg(Blockly.Msg.MATH_CONSTRAIN_TITLE,
                         ['VALUE', 'Number', Blockly.ALIGN_RIGHT],
@@ -338,7 +328,6 @@ Blockly.Blocks.math_random_int = {
   // Random integer between [X] and [Y].
   init: function() {
     this.setHelpUrl(Blockly.Msg.MATH_RANDOM_INT_HELPURL);
-    this.setHSV(258, 0.35, 0.62);
     this.setOutput(true, Blockly.BlockValueType.NUMBER);
     this.interpolateMsg(Blockly.Msg.MATH_RANDOM_INT_TITLE,
                         ['FROM', 'Number', Blockly.ALIGN_RIGHT],
@@ -353,7 +342,6 @@ Blockly.Blocks.math_random_float = {
   // Random fraction between 0 and 1.
   init: function() {
     this.setHelpUrl(Blockly.Msg.MATH_RANDOM_FLOAT_HELPURL);
-    this.setHSV(258, 0.35, 0.62);
     this.setOutput(true, Blockly.BlockValueType.NUMBER);
     this.appendDummyInput()
         .appendTitle(Blockly.Msg.MATH_RANDOM_FLOAT_TITLE_RANDOM);

--- a/blocks/text.js
+++ b/blocks/text.js
@@ -32,7 +32,6 @@ Blockly.Blocks.text = {
   // Text value.
   init: function() {
     this.setHelpUrl(Blockly.Msg.TEXT_TEXT_HELPURL);
-    this.setColour(160);
     this.appendDummyInput()
         .appendTitle(new Blockly.FieldImage(
               Blockly.assetUrl('media/quote0.png'), 12, 12))
@@ -48,7 +47,6 @@ Blockly.Blocks.text_join = {
   // Create a string made up of any number of elements of any type.
   init: function() {
     this.setHelpUrl(Blockly.Msg.TEXT_JOIN_HELPURL);
-    this.setColour(160);
     this.appendValueInput('ADD0')
         .appendTitle(Blockly.Msg.TEXT_JOIN_TITLE_CREATEWITH);
     this.appendValueInput('ADD1');
@@ -252,7 +250,6 @@ Blockly.Blocks.text_charAt = {
          [Blockly.Msg.TEXT_CHARAT_LAST, 'LAST'],
          [Blockly.Msg.TEXT_CHARAT_RANDOM, 'RANDOM']];
     this.setHelpUrl(Blockly.Msg.TEXT_CHARAT_HELPURL);
-    this.setColour(160);
     this.setOutput(true, Blockly.BlockValueType.STRING);
     this.appendValueInput('VALUE')
         .setCheck(Blockly.BlockValueType.STRING)
@@ -324,7 +321,6 @@ Blockly.Blocks.text_getSubstring = {
          [Blockly.Msg.TEXT_GET_SUBSTRING_END_FROM_END, 'FROM_END'],
          [Blockly.Msg.TEXT_GET_SUBSTRING_END_LAST, 'LAST']];
     this.setHelpUrl(Blockly.Msg.TEXT_GET_SUBSTRING_HELPURL);
-    this.setColour(160);
     this.appendValueInput('STRING')
         .setCheck(Blockly.BlockValueType.STRING)
         .appendTitle(Blockly.Msg.TEXT_GET_SUBSTRING_INPUT_IN_TEXT);
@@ -406,7 +402,6 @@ Blockly.Blocks.text_changeCase = {
          [Blockly.Msg.TEXT_CHANGECASE_OPERATOR_LOWERCASE, 'LOWERCASE'],
          [Blockly.Msg.TEXT_CHANGECASE_OPERATOR_TITLECASE, 'TITLECASE']];
     this.setHelpUrl(Blockly.Msg.TEXT_CHANGECASE_HELPURL);
-    this.setColour(160);
     this.appendValueInput('TEXT')
         .setCheck(Blockly.BlockValueType.STRING)
         .appendTitle(new Blockly.FieldDropdown(OPERATORS), 'CASE');
@@ -423,7 +418,6 @@ Blockly.Blocks.text_trim = {
          [Blockly.Msg.TEXT_TRIM_OPERATOR_LEFT, 'LEFT'],
          [Blockly.Msg.TEXT_TRIM_OPERATOR_RIGHT, 'RIGHT']];
     this.setHelpUrl(Blockly.Msg.TEXT_TRIM_HELPURL);
-    this.setColour(160);
     this.appendValueInput('TEXT')
         .setCheck(Blockly.BlockValueType.STRING)
         .appendTitle(new Blockly.FieldDropdown(OPERATORS), 'MODE');
@@ -455,7 +449,6 @@ Blockly.Blocks.text_prompt = {
     // Assign 'this' to a variable for use in the closure below.
     var thisBlock = this;
     this.setHelpUrl(Blockly.Msg.TEXT_PROMPT_HELPURL);
-    this.setColour(160);
     var dropdown = new Blockly.FieldDropdown(TYPES, function(newOp) {
       if (newOp == 'NUMBER') {
         thisBlock.outputConnection.setCheck(Blockly.BlockValueType.NUMBER);

--- a/core/connections/connection.js
+++ b/core/connections/connection.js
@@ -432,10 +432,14 @@ Blockly.Connection.prototype.colorForType = function(checks) {
       return [160, 0.45, 0.65];
     case 'Number':
       return [258, 0.35, 0.62];
+    case 'Boolean':
+      return [196, 1.0, 0.79];
+    case 'Array':
+      return [40, 1.0, 0.99];
     case 'Colour':
       return [196, 1.0, 0.79];
     case 'Sprite':
-      return [0, 0.45, 0.65];
+      return [355, 0.70, 0.70];
     case 'Behavior':
       return [136, 0.84, 0.80];
     case 'Location':

--- a/core/connections/connection.js
+++ b/core/connections/connection.js
@@ -776,6 +776,12 @@ Blockly.Connection.prototype.setCheck = function(check, opt_strict) {
       // Bump away.
       this.sourceBlock_.bumpNeighbours_();
     }
+
+    // If the setting an output check, and the block has no color, make the
+    // block the default color for the given output type.
+    if (this.type === Blockly.OUTPUT_VALUE && !this.sourceBlock_.getColour()) {
+      this.sourceBlock_.setHSV.apply(this.sourceBlock_, this.colorForType(check));
+    }
   } else {
     this.check_ = null;
   }

--- a/core/connections/connection.js
+++ b/core/connections/connection.js
@@ -435,11 +435,11 @@ Blockly.Connection.prototype.colorForType = function(checks) {
     case 'Colour':
       return '#0094ca';
     case 'Sprite':
-      return '#399e4b';
+      return '#b33540';
     case 'Behavior':
-      return '#d1c404';
+      return '#20cc4e';
     case 'Location':
-      return '#f318a2';
+      return '#ebd546';
     default:
       return;
   }

--- a/core/connections/connection.js
+++ b/core/connections/connection.js
@@ -429,17 +429,17 @@ Blockly.Connection.prototype.colorForType = function(checks) {
   }
   switch (checks[0]) {
     case 'String':
-      return '#5ba68d';
+      return [160, 0.45, 0.65];
     case 'Number':
-      return '#77679e';
+      return [258, 0.35, 0.62];
     case 'Colour':
-      return '#0094ca';
+      return [196, 1.0, 0.79];
     case 'Sprite':
-      return '#b33540';
+      return [0, 0.45, 0.65];
     case 'Behavior':
-      return '#20cc4e';
+      return [136, 0.84, 0.80];
     case 'Location':
-      return '#ebd546';
+      return [52, 0.70, 0.92];
     default:
       return;
   }

--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -2015,6 +2015,9 @@ Blockly.Block.prototype.setOutput = function(hasOutput, opt_check, opt_strict) {
         new Blockly.Connection(this, Blockly.OUTPUT_VALUE);
     this.outputConnection.setCheck(opt_check, opt_strict);
   }
+  if (opt_check && !(opt_check instanceof Array) && !this.colourHue_) {
+    this.setHSV.apply(this, this.outputConnection.colorForType([opt_check]));
+  }
   this.refreshRender();
 };
 

--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -2015,9 +2015,6 @@ Blockly.Block.prototype.setOutput = function(hasOutput, opt_check, opt_strict) {
         new Blockly.Connection(this, Blockly.OUTPUT_VALUE);
     this.outputConnection.setCheck(opt_check, opt_strict);
   }
-  if (opt_check && !(opt_check instanceof Array) && !this.colourHue_) {
-    this.setHSV.apply(this, this.outputConnection.colorForType([opt_check]));
-  }
   this.refreshRender();
 };
 

--- a/core/ui/block_svg/block_svg.js
+++ b/core/ui/block_svg/block_svg.js
@@ -1180,11 +1180,12 @@ Blockly.BlockSvg.prototype.renderDraw_ = function(iconWidth, inputRows) {
     });
     for (var j = 0; j < this.svgTypeHints_.children.length; j++) {
       var pathInfo = typeHints[j];
-      if (pathInfo) {
+      if (pathInfo && pathInfo.color) {
         this.svgTypeHints_.children[j].setAttribute('d', pathInfo.steps);
         this.svgTypeHints_.children[j].setAttribute('transform',
           pathInfo.transform);
-        this.svgTypeHints_.children[j].setAttribute('stroke', pathInfo.color);
+        this.svgTypeHints_.children[j].setAttribute('stroke',
+          Blockly.makeColour.apply(null, pathInfo.color));
       } else {
         this.svgTypeHints_.children[j].setAttribute('d', '');
       }

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -33,7 +33,7 @@ function start() {
     hasVerticalScrollbars: true,
     assetUrl: function(path) { return '../' + path; },
     customSimpleDialog: Blockly.Playground.customSimpleDialog,
-    valueTypeTabShapeMap: { Sprite: 'angle', Behavior: 'square', Location: 'rounded' },
+    valueTypeTabShapeMap: { Sprite: 'angle', Behavior: 'rounded', Location: 'square' },
     typeHints: goog.tweak.getBoolean('typeHints')
   });
 

--- a/tests/playground_requires.js
+++ b/tests/playground_requires.js
@@ -70,7 +70,7 @@ Blockly.Playground.customSimpleDialog = function (dialogOptions) {
   dialog.setVisible(true);
 };
 
-function createVariableGet(type, color) {
+function createVariableGet(type) {
   return {
     // Variable getter.
     init: function() {
@@ -78,7 +78,6 @@ function createVariableGet(type, color) {
       // Must be marked EDITABLE so that cloned blocks share the same var name
       fieldLabel.EDITABLE = true;
       this.setHelpUrl(Blockly.Msg.VARIABLES_GET_HELPURL);
-      this.setHSV.apply(this, color);
       this.appendDummyInput()
         .appendTitle(Blockly.Msg.VARIABLES_GET_TITLE)
         .appendTitle(Blockly.disableVariableEditing ? fieldLabel
@@ -90,7 +89,7 @@ function createVariableGet(type, color) {
   }
 }
 
-function createVariableSet(type, color) {
+function createVariableSet(type) {
   return {
     // Variable setter.
     init: function() {
@@ -98,7 +97,7 @@ function createVariableSet(type, color) {
       // Must be marked EDITABLE so that cloned blocks share the same var name
       fieldLabel.EDITABLE = true;
       this.setHelpUrl(Blockly.Msg.VARIABLES_SET_HELPURL);
-      this.setHSV.apply(this, color);
+      this.setHSV(312, 0.32, 0.62);
       this.appendValueInput('VALUE')
         .setStrictCheck(type)
         .appendTitle(Blockly.Msg.VARIABLES_SET_TITLE)
@@ -123,14 +122,14 @@ function createVariableSet(type, color) {
   }
 }
 
-Blockly.Blocks.sprite_variables_get = createVariableGet(Blockly.BlockValueType.SPRITE, [355, 0.70, 0.70]);
-Blockly.Blocks.sprite_variables_set = createVariableSet(Blockly.BlockValueType.SPRITE, [312, 0.32, 0.62]);
+Blockly.Blocks.sprite_variables_get = createVariableGet(Blockly.BlockValueType.SPRITE);
+Blockly.Blocks.sprite_variables_set = createVariableSet(Blockly.BlockValueType.SPRITE);
 
-Blockly.Blocks.behavior_variables_get = createVariableGet(Blockly.BlockValueType.BEHAVIOR, [136, 0.84, 0.80]);
-Blockly.Blocks.behavior_variables_set = createVariableSet(Blockly.BlockValueType.BEHAVIOR, [312, 0.32, 0.62]);
+Blockly.Blocks.behavior_variables_get = createVariableGet(Blockly.BlockValueType.BEHAVIOR);
+Blockly.Blocks.behavior_variables_set = createVariableSet(Blockly.BlockValueType.BEHAVIOR);
 
-Blockly.Blocks.location_variables_get = createVariableGet(Blockly.BlockValueType.LOCATION, [52, 0.70, 0.92]);
-Blockly.Blocks.location_variables_set = createVariableSet(Blockly.BlockValueType.LOCATION, [312, 0.32, 0.62]);
+Blockly.Blocks.location_variables_get = createVariableGet(Blockly.BlockValueType.LOCATION);
+Blockly.Blocks.location_variables_set = createVariableSet(Blockly.BlockValueType.LOCATION);
 
 Blockly.Blocks.button_block = {
   // Example block with button field

--- a/tests/playground_requires.js
+++ b/tests/playground_requires.js
@@ -123,13 +123,13 @@ function createVariableSet(type, color) {
   }
 }
 
-Blockly.Blocks.sprite_variables_get = createVariableGet(Blockly.BlockValueType.SPRITE, [131, 0.64, 0.62]);
+Blockly.Blocks.sprite_variables_get = createVariableGet(Blockly.BlockValueType.SPRITE, [355, 0.70, 0.70]);
 Blockly.Blocks.sprite_variables_set = createVariableSet(Blockly.BlockValueType.SPRITE, [312, 0.32, 0.62]);
 
-Blockly.Blocks.behavior_variables_get = createVariableGet(Blockly.BlockValueType.BEHAVIOR, [52, .98, .82]);
+Blockly.Blocks.behavior_variables_get = createVariableGet(Blockly.BlockValueType.BEHAVIOR, [136, 0.84, 0.80]);
 Blockly.Blocks.behavior_variables_set = createVariableSet(Blockly.BlockValueType.BEHAVIOR, [312, 0.32, 0.62]);
 
-Blockly.Blocks.location_variables_get = createVariableGet(Blockly.BlockValueType.LOCATION, [322, 0.90, 0.95]);
+Blockly.Blocks.location_variables_get = createVariableGet(Blockly.BlockValueType.LOCATION, [52, 0.70, 0.92]);
 Blockly.Blocks.location_variables_set = createVariableSet(Blockly.BlockValueType.LOCATION, [312, 0.32, 0.62]);
 
 Blockly.Blocks.button_block = {


### PR DESCRIPTION
One thing I found during this process:

The only place we use multiple type checks (vs. None or exactly 1 type) is for the the `text_length` / `list_length` and `text_empty` / `list_empty` blocks.  https://github.com/code-dot-org/blockly/blob/261ac3f64b7d5f0bb3303c6104d0e954009c2f34/blocks/lists.js#L179

Since they're separate blocks, we could collapse them to only take the corresponding type.  I think it's just an ease-of-use feature to allow them to be used interchangeably on strings and lists.