### PR TITLE
Only override clipboard events when a block is selected

### DIFF
--- a/core/ui/block_space/block_space_editor.js
+++ b/core/ui/block_space/block_space_editor.js
@@ -748,8 +748,10 @@ Blockly.BlockSpaceEditor.prototype.onKeyDown_ = function(e) {
  * @private
  */
 Blockly.BlockSpaceEditor.prototype.onCutCopy_ = function(e) {
-  e.clipboardData.setData('text/xml', Blockly.clipboard_);
-  e.preventDefault();
+  if (Blockly.selected) {
+    e.clipboardData.setData('text/xml', Blockly.clipboard_);
+    e.preventDefault();
+  }
 };
 
 /**


### PR DESCRIPTION
Don't swallow non-Blockly cut/copy events.