### PR TITLE
Parameter type mutation

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -133,6 +133,7 @@ Blockly.Block.createProcedureDefinitionBlock = function(config) {
         var paramBlock = new Blockly.Block(blockSpace, 'procedures_mutatorarg');
         paramBlock.initSvg();
         paramBlock.setTitleValue(this.parameterNames_[x], 'NAME');
+        paramBlock.setTitleValue(this.parameterTypes_[x], 'TYPE');
         // Store the old location.
         paramBlock.oldLocation = x;
         connection.connect(paramBlock.previousConnection);
@@ -154,6 +155,7 @@ Blockly.Block.createProcedureDefinitionBlock = function(config) {
       var paramIDs = [];
       while (currentParamBlock) {
         paramNames.push(currentParamBlock.getTitleValue('NAME'));
+        paramTypes.push(currentParamBlock.getTitleValue('TYPE'));
         paramIDs.push(currentParamBlock.id);
         currentParamBlock = currentParamBlock.nextConnection &&
           currentParamBlock.nextConnection.targetBlock();
@@ -360,6 +362,17 @@ Blockly.Blocks.procedures_mutatorarg = {
     this.appendDummyInput()
         .appendTitle(Blockly.Msg.PROCEDURES_MUTATORARG_TITLE)
         .appendTitle(new Blockly.FieldTextInput('x', this.validator), 'NAME');
+    if (Blockly.typeHints) {
+      var typeOptions = function () {
+        return goog.object.getValues(Blockly.BlockValueType).map(function (v) {
+          return [v, v];
+        });
+      };
+      this.appendDummyInput()
+        .appendTitle(Blockly.Msg.PROCEDURES_MUTATORARG_TYPE)
+        .appendTitle(new Blockly.FieldDropdown(typeOptions), 'TYPE');
+      this.setInputsInline(true);
+    }
     this.setPreviousStatement(true);
     this.setNextStatement(true);
     this.setTooltip('');

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -511,7 +511,9 @@ Blockly.Blocks.procedures_callnoreturn = {
     for (var x = 0; x < this.currentParameterNames_.length; x++) {
       var parameter = document.createElement('arg');
       parameter.setAttribute('name', this.currentParameterNames_[x]);
-      parameter.setAttribute('type', this.currentParameterTypes_[x]);
+      if (this.currentParameterTypes_[x]) {
+        parameter.setAttribute('type', this.currentParameterTypes_[x]);
+      }
       container.appendChild(parameter);
     }
     return container;

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -362,7 +362,7 @@ Blockly.Blocks.procedures_mutatorarg = {
     this.appendDummyInput()
         .appendTitle(Blockly.Msg.PROCEDURES_MUTATORARG_TITLE)
         .appendTitle(new Blockly.FieldTextInput('x', this.validator), 'NAME');
-    if (Blockly.typeHints) {
+    if (Blockly.valueTypeTabShapeMap) {
       var typeOptions = function () {
         return goog.object.getValues(Blockly.BlockValueType).map(function (v) {
           return [v, v];

--- a/core/ui/block_svg/block_svg.js
+++ b/core/ui/block_svg/block_svg.js
@@ -1172,24 +1172,25 @@ Blockly.BlockSvg.prototype.renderDraw_ = function(iconWidth, inputRows) {
     this.svgPathFill_.setAttribute('d', pathString);
   }
   if (this.svgTypeHints_) {
-    var typeHints = [];
-    this.block_.inputList.forEach(function (input) {
-      if (input.connection) {
-        typeHints.push(input.connection.getPathInfo());
+    var g = this.svgTypeHints_;
+    this.block_.inputList.forEach(function (input, j) {
+      if (!input.connection) {
+        return;
       }
-    });
-    for (var j = 0; j < this.svgTypeHints_.children.length; j++) {
-      var pathInfo = typeHints[j];
+      var pathInfo = input.connection.getPathInfo();
+      var element = g.children[j] || Blockly.createSvgElement('path', {
+        'filter': 'url(#blocklyTypeHintFilter)'
+      }, g);
       if (pathInfo && pathInfo.color) {
-        this.svgTypeHints_.children[j].setAttribute('d', pathInfo.steps);
-        this.svgTypeHints_.children[j].setAttribute('transform',
+        element.setAttribute('d', pathInfo.steps);
+        element.setAttribute('transform',
           pathInfo.transform);
-        this.svgTypeHints_.children[j].setAttribute('stroke',
+        element.setAttribute('stroke',
           Blockly.makeColour.apply(null, pathInfo.color));
       } else {
-        this.svgTypeHints_.children[j].setAttribute('d', '');
+        element.setAttribute('d', '');
       }
-    }
+    });
   }
   this.svgPathDark_.setAttribute('d', pathString);
   pathString = renderInfo.highlight.join(' ') + '\n' + renderInfo.highlightInline.join(' ');

--- a/core/ui/block_svg/block_svg.js
+++ b/core/ui/block_svg/block_svg.js
@@ -1173,14 +1173,18 @@ Blockly.BlockSvg.prototype.renderDraw_ = function(iconWidth, inputRows) {
   }
   if (this.svgTypeHints_) {
     var g = this.svgTypeHints_;
-    this.block_.inputList.forEach(function (input, j) {
-      if (!input.connection) {
-        return;
-      }
-      var pathInfo = input.connection.getPathInfo();
+    var max = Math.max(this.block_.inputList.length, g.children.length);
+    for (var j = 0; j < max; j++) {
       var element = g.children[j] || Blockly.createSvgElement('path', {
         'filter': 'url(#blocklyTypeHintFilter)'
       }, g);
+      var input = this.block_.inputList[j];
+      if (!input || !input.connection) {
+        element.setAttribute('d', '');
+        continue;
+      }
+
+      var pathInfo = input.connection.getPathInfo();
       if (pathInfo && pathInfo.color) {
         element.setAttribute('d', pathInfo.steps);
         element.setAttribute('transform',
@@ -1190,7 +1194,7 @@ Blockly.BlockSvg.prototype.renderDraw_ = function(iconWidth, inputRows) {
       } else {
         element.setAttribute('d', '');
       }
-    });
+    }
   }
   this.svgPathDark_.setAttribute('d', pathString);
   pathString = renderInfo.highlight.join(' ') + '\n' + renderInfo.highlightInline.join(' ');

--- a/msg/js/en_us.js
+++ b/msg/js/en_us.js
@@ -309,6 +309,7 @@ Blockly.Msg.PROCEDURES_HIGHLIGHT_DEF = "Highlight function definition";
 Blockly.Msg.PROCEDURES_IFRETURN_TOOLTIP = "If a value is true, then return a second value.";
 Blockly.Msg.PROCEDURES_IFRETURN_WARNING = "Warning: This block may be used only within a function definition.";
 Blockly.Msg.PROCEDURES_MUTATORARG_TITLE = "input name:";
+Blockly.Msg.PROCEDURES_MUTATORARG_TYPE = 'type:';
 Blockly.Msg.PROCEDURES_MUTATORCONTAINER_TITLE = "inputs";
 Blockly.Msg.REMOVE_COMMENT = "Remove Comment";
 Blockly.Msg.RENAME_PARAMETER = "Rename parameter...";

--- a/tests/blocks_test.js
+++ b/tests/blocks_test.js
@@ -358,3 +358,40 @@ function test_unknownLanguageBlocks() {
 
   goog.dom.removeNode(containerDiv);
 }
+
+function test_typedParams() {
+  var containerDiv = Blockly.Test.initializeBlockSpaceEditor();
+  var blockSpace = Blockly.mainBlockSpace;
+
+  Blockly.Xml.domToBlockSpace(blockSpace, Blockly.Xml.textToDom(
+    '<xml>' +
+      '<block type="procedures_defnoreturn">' +
+        '<mutation>' +
+          '<arg name="x" type="Number"></arg>' +
+          '<arg name="y" type="Number"></arg>' +
+        '</mutation>' +
+        '<title name="NAME">do something</title>' +
+      '</block>' +
+      '<block type="procedures_callnoreturn" inline="false">' +
+        '<mutation name="do something">' +
+          '<arg name="x" type="Number"></arg>' +
+          '<arg name="y" type="Number"></arg>' +
+        '</mutation>' +
+      '</block>' +
+    '</xml>'
+  ));
+
+  var blocks = Blockly.mainBlockSpace.getTopBlocks();
+  var definition = blocks[0];
+  var call = blocks[1];
+
+  definition.updateParamsFromArrays(['abc', 'def'], [1, 2], ['String', 'Sprite']);
+
+  var procInfo = definition.getProcedureInfo();
+
+  assert(goog.array.equals(['abc', 'def'], procInfo.parameterNames));
+  assert(goog.array.equals(['String', 'Sprite'], procInfo.parameterTypes));
+  assert(goog.array.equals(['String', 'Sprite'], call.currentParameterTypes_));
+
+  goog.dom.removeNode(containerDiv);
+}


### PR DESCRIPTION
I extracted this isolated feature from PR https://github.com/code-dot-org/blockly/pull/118.  Allow any procedure to have optional type information (and strict checks) for its parameters.

![typed-params](https://user-images.githubusercontent.com/413693/40945264-e6e298c6-680c-11e8-93dd-638ceab17dca.gif)

The "type" dropdown is only provided when `Blockly.typeHints` are enabled.