### PR TITLE
Pass `opt_keepCallers` as true to avoid double-dispose of call blocks in flyout

### DIFF
--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -377,7 +377,7 @@ Blockly.Flyout.prototype.hide = function(opt_saveBlock) {
   // Delete all the blocks.
   this.blockSpace_.getTopBlocks(false).forEach(function (block) {
     if (block.rendered && block !== opt_saveBlock) {
-      block.dispose(false, false);
+      block.dispose(false, false, true);
     }
   });
   // Delete all the background buttons.


### PR DESCRIPTION
The normal dispose path for blocks in a flyout is here:

https://github.com/code-dot-org/blockly/blob/c93d76cb2c14399bf8929291a0f491fb967917a8/core/ui/block_space/flyout.js#L760-L773

However there is a second unintended path for call blocks, which causes them to be disposed twice:

https://github.com/code-dot-org/blockly/blob/c93d76cb2c14399bf8929291a0f491fb967917a8/core/ui/block_space/flyout.js#L377-L382

Here `opt_saveBlock` is the call block we want to keep — so all is good.  Except: procedure definition blocks override `dispose` to also remove matching call blocks:

https://github.com/code-dot-org/blockly/blob/c93d76cb2c14399bf8929291a0f491fb967917a8/blocks/procedures.js#L196-L204

The fix is to pass `opt_keepCallers` as true, since we're going to handle destroying the block ourself later.