### PR TITLE
Allow pasting blocks from other applications

### DIFF
--- a/core/ui/block_space/block_space_editor.js
+++ b/core/ui/block_space/block_space_editor.js
@@ -761,7 +761,7 @@ Blockly.BlockSpaceEditor.prototype.onCutCopy_ = function(e) {
  */
 Blockly.BlockSpaceEditor.prototype.onPaste_ = function(e) {
   try {
-    var xml = Blockly.Xml.textToDom(e.clipboardData.getData('text/xml'));
+    var xml = Blockly.Xml.textToDom(e.clipboardData.getData('text/xml') || e.clipboardData.getData('text/plain'));
     Blockly.focusedBlockSpace.paste({
       dom: xml.firstElementChild
     });


### PR DESCRIPTION
For example, pasting raw XML from Slack into a block space.  A user should be able to copy the following to their clipboard, then paste it into Blockly:

```xml
<xml>
  <block type="colour_blend" inline="false"></block>
</xml>
```

1. Is there XML on the clipboard?  If yes, use that.
2. Otherwise use the plain text from the clipboard.

https://docs.google.com/document/d/1wJMKXJS6Z8tsYQRRq93r7k4TTzG4jQbIXfKdKcSTZTI/edit#heading=h.njzku5ndadkc