### PR TITLE
Disambiguate (bump) connections of the same type

### DIFF
--- a/core/connections/connection.js
+++ b/core/connections/connection.js
@@ -835,19 +835,20 @@ Blockly.Connection.prototype.neighbours_ = function(maxLimit) {
 
   // Construct a new connection DB, with matching and opposing connections.
   var db = [];
-  var a = 0, b = 0;
+  var a = 0, b = 0, connection;
   while (a < db1.length || b < db2.length) {
     if (!db2[b] || (db1[a] && db1[a].y_ < db2[b].y_)) {
-      db.push(db1[a]);
+      connection = db1[a];
+      if (connection !== this) {
+        db.push(connection)
+      }
       a++;
     } else {
-      db.push(db2[b]);
+      connection = db2[b];
+      if (connection !== this) {
+        db.push(connection)
+      }
       b++;
-    }
-  }
-  for (var i = 0; i < db.length; i++) {
-    if (i === this) {
-      db.splice(i, 1);
     }
   }
 

--- a/core/connections/connection.js
+++ b/core/connections/connection.js
@@ -393,6 +393,7 @@ Blockly.Connection.prototype.bumpAwayFrom_ = function(staticConnection) {
     dx = -dx;
   }
   rootBlock.moveBy(dx, dy);
+  rootBlock.bumpNeighbours_();
 };
 
 /**

--- a/core/connections/connection.js
+++ b/core/connections/connection.js
@@ -829,7 +829,26 @@ Blockly.Connection.prototype.getCheck = function () {
 Blockly.Connection.prototype.neighbours_ = function(maxLimit) {
   // Determine the opposite type of connection.
   var oppositeType = Blockly.OPPOSITE_TYPE[this.type];
-  var db = this.dbList_[oppositeType];
+  var db1 = this.dbList_[this.type];
+  var db2 = this.dbList_[oppositeType];
+
+  // Construct a new connection DB, with matching and opposing connections.
+  var db = [];
+  var a = 0, b = 0;
+  while (a < db1.length || b < db2.length) {
+    if (!db2[b] || (db1[a] && db1[a].y_ < db2[b].y_)) {
+      db.push(db1[a]);
+      a++;
+    } else {
+      db.push(db2[b]);
+      b++;
+    }
+  }
+  for (var i = 0; i < db.length; i++) {
+    if (i === this) {
+      db.splice(i, 1);
+    }
+  }
 
   var currentX = this.x_;
   var currentY = this.y_;

--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1358,13 +1358,28 @@ Blockly.Block.prototype.bumpNeighbours_ = function() {
       // If both connections are connected, that's probably fine.  But if
       // either one of them is unconnected, then there could be confusion.
       if (!connection.targetConnection || !otherConnection.targetConnection) {
+        // If one is connected and the other is unconnected, always bump the
+        // unconnected block.
+        if (connection.targetConnection && !otherConnection.targetConnection) {
+          otherConnection.bumpAwayFrom_(connection);
+        } else if (!connection.targetConnection && otherConnection.targetConnection) {
+          connection.bumpAwayFrom_(otherConnection);
         // Only bump blocks if they are from different tree structures.
-        if (otherConnection.sourceBlock_.getRootBlock() != rootBlock) {
+        } else if (otherConnection.sourceBlock_.getRootBlock() != rootBlock) {
           // Always bump the inferior block.
-          if (connection.isSuperior()) {
-            otherConnection.bumpAwayFrom_(connection);
+          if (connection.isSuperior() ^ otherConnection.isSuperior()) {
+            if (connection.isSuperior()) {
+              otherConnection.bumpAwayFrom_(connection);
+            } else {
+              connection.bumpAwayFrom_(otherConnection);
+            }
+          // If connections are the same type, bump the newer block.
           } else {
-            connection.bumpAwayFrom_(otherConnection);
+            if (connection.sourceBlock_.id > otherConnection.sourceBlock_.id) {
+              connection.bumpAwayFrom_(otherConnection);
+            } else {
+              otherConnection.bumpAwayFrom_(connection);
+            }
           }
         }
       }

--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1358,6 +1358,7 @@ Blockly.Block.prototype.bumpNeighbours_ = function() {
       // If both connections are connected, that's probably fine.  But if
       // either one of them is unconnected, then there could be confusion.
       if (!connection.targetConnection || !otherConnection.targetConnection) {
+        var otherRootBlock = otherConnection.sourceBlock_.getRootBlock();
         // If one is connected and the other is unconnected, always bump the
         // unconnected block.
         if (connection.targetConnection && !otherConnection.targetConnection) {
@@ -1365,7 +1366,7 @@ Blockly.Block.prototype.bumpNeighbours_ = function() {
         } else if (!connection.targetConnection && otherConnection.targetConnection) {
           connection.bumpAwayFrom_(otherConnection);
         // Only bump blocks if they are from different tree structures.
-        } else if (otherConnection.sourceBlock_.getRootBlock() != rootBlock) {
+        } else if (otherRootBlock !== rootBlock) {
           // Always bump the inferior block.
           if (connection.isSuperior() ^ otherConnection.isSuperior()) {
             if (connection.isSuperior()) {
@@ -1373,12 +1374,21 @@ Blockly.Block.prototype.bumpNeighbours_ = function() {
             } else {
               connection.bumpAwayFrom_(otherConnection);
             }
-          // If connections are the same type, bump the newer block.
+          // If connections are the same type, bump the block that is lower on the screen.
           } else {
-            if (connection.sourceBlock_.id > otherConnection.sourceBlock_.id) {
+            var rootY = rootBlock.getRelativeToSurfaceXY().y;
+            var otherY = otherRootBlock.getRelativeToSurfaceXY().y;
+            if (rootY > otherY) {
               connection.bumpAwayFrom_(otherConnection);
-            } else {
+            } else if (rootY < otherY) {
               otherConnection.bumpAwayFrom_(connection);
+              // If connections are the same location, bump the newer block.
+            } else {
+              if (connection.sourceBlock_.id > otherConnection.sourceBlock_.id) {
+                connection.bumpAwayFrom_(otherConnection);
+              } else {
+                otherConnection.bumpAwayFrom_(connection);
+              }
             }
           }
         }

--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1357,40 +1357,35 @@ Blockly.Block.prototype.bumpNeighbours_ = function() {
       var otherConnection = neighbours[y];
       // If both connections are connected, that's probably fine.  But if
       // either one of them is unconnected, then there could be confusion.
-      if (!connection.targetConnection || !otherConnection.targetConnection) {
-        var otherRootBlock = otherConnection.sourceBlock_.getRootBlock();
-        // If one is connected and the other is unconnected, always bump the
-        // unconnected block.
-        if (connection.targetConnection && !otherConnection.targetConnection) {
+      if (connection.targetConnection && otherConnection.targetConnection) {
+        continue;
+      }
+      // Only bump blocks if they are from different tree structures.
+      var otherRootBlock = otherConnection.sourceBlock_.getRootBlock();
+      if (otherRootBlock === rootBlock) {
+        continue;
+      }
+      // When bumping connections of opposite types, always bump the inferior block.
+      if (connection.type !== otherConnection.type) {
+        if (connection.isSuperior()) {
           otherConnection.bumpAwayFrom_(connection);
-        } else if (!connection.targetConnection && otherConnection.targetConnection) {
+        } else {
           connection.bumpAwayFrom_(otherConnection);
-        // Only bump blocks if they are from different tree structures.
-        } else if (otherRootBlock !== rootBlock) {
-          // Always bump the inferior block.
-          if (connection.isSuperior() ^ otherConnection.isSuperior()) {
-            if (connection.isSuperior()) {
-              otherConnection.bumpAwayFrom_(connection);
-            } else {
-              connection.bumpAwayFrom_(otherConnection);
-            }
-          // If connections are the same type, bump the block that is lower on the screen.
-          } else {
-            var rootY = rootBlock.getRelativeToSurfaceXY().y;
-            var otherY = otherRootBlock.getRelativeToSurfaceXY().y;
-            if (rootY > otherY) {
-              connection.bumpAwayFrom_(otherConnection);
-            } else if (rootY < otherY) {
-              otherConnection.bumpAwayFrom_(connection);
-              // If connections are the same location, bump the newer block.
-            } else {
-              if (connection.sourceBlock_.id > otherConnection.sourceBlock_.id) {
-                connection.bumpAwayFrom_(otherConnection);
-              } else {
-                otherConnection.bumpAwayFrom_(connection);
-              }
-            }
-          }
+        }
+      // If one is connected and the other is unconnected, always bump the
+      // unconnected block.
+      } else if (connection.targetConnection && !otherConnection.targetConnection) {
+        otherConnection.bumpAwayFrom_(connection);
+      } else if (!connection.targetConnection && otherConnection.targetConnection) {
+        connection.bumpAwayFrom_(otherConnection);
+      // Otherwise bump the block that is lower on the screen.
+      } else {
+        var rootY = rootBlock.getRelativeToSurfaceXY().y;
+        var otherY = otherRootBlock.getRelativeToSurfaceXY().y;
+        if (rootY > otherY) {
+          connection.bumpAwayFrom_(otherConnection);
+        } else {
+          otherConnection.bumpAwayFrom_(connection);
         }
       }
     }

--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1365,28 +1365,28 @@ Blockly.Block.prototype.bumpNeighbours_ = function() {
       if (otherRootBlock === rootBlock) {
         continue;
       }
+
+      var bumpOther = false;
       // When bumping connections of opposite types, always bump the inferior block.
       if (connection.type !== otherConnection.type) {
-        if (connection.isSuperior()) {
-          otherConnection.bumpAwayFrom_(connection);
-        } else {
-          connection.bumpAwayFrom_(otherConnection);
-        }
+        bumpOther = connection.isSuperior();
       // If one is connected and the other is unconnected, always bump the
       // unconnected block.
       } else if (connection.targetConnection && !otherConnection.targetConnection) {
-        otherConnection.bumpAwayFrom_(connection);
+        bumpOther = true;
       } else if (!connection.targetConnection && otherConnection.targetConnection) {
-        connection.bumpAwayFrom_(otherConnection);
+        bumpOther = false;
       // Otherwise bump the block that is lower on the screen.
       } else {
         var rootY = rootBlock.getRelativeToSurfaceXY().y;
         var otherY = otherRootBlock.getRelativeToSurfaceXY().y;
-        if (rootY > otherY) {
-          connection.bumpAwayFrom_(otherConnection);
-        } else {
-          otherConnection.bumpAwayFrom_(connection);
-        }
+        bumpOther = rootY < otherY;
+      }
+
+      if (bumpOther) {
+        otherConnection.bumpAwayFrom_(connection);
+      } else {
+        connection.bumpAwayFrom_(otherConnection);
       }
     }
   }

--- a/tests/block_space_test.js
+++ b/tests/block_space_test.js
@@ -35,6 +35,26 @@ function test_initializeBlockSpace() {
 function test_blockSpaceBumpsBlocks() {
   var container = Blockly.Test.initializeBlockSpaceEditor();
 
+  var blockXML = '<xml><block type="text_print" x="100" y="100"></block><block type="text" x="150" y="100"><title name="TEXT"></title></block></xml>';
+  Blockly.Xml.domToBlockSpace(Blockly.mainBlockSpace, Blockly.Xml.textToDom(blockXML));
+  var parent = Blockly.mainBlockSpace.getTopBlocks()[0];
+  var child = Blockly.mainBlockSpace.getTopBlocks()[1];
+  assertEquals('text_print', parent.type);
+  assertEquals('text', child.type);
+  assertEquals(150, child.getRelativeToSurfaceXY().x);
+  assertEquals(100, child.getRelativeToSurfaceXY().y);
+  var connection = parent.getConnections_()[2];
+
+  parent.bumpNeighbours_();
+  assertEquals(connection.x_ + Blockly.SNAP_RADIUS, child.getRelativeToSurfaceXY().x);
+  assertEquals(connection.y_ + Blockly.SNAP_RADIUS * 2, child.getRelativeToSurfaceXY().y);
+
+  goog.dom.removeNode(container);
+}
+
+function test_bumpNeighbours() {
+  var container = Blockly.Test.initializeBlockSpaceEditor();
+
   var blockXML = '<xml><block type="math_number"><title name="NUM">0</title></block></xml>';
   Blockly.Xml.domToBlockSpace(Blockly.mainBlockSpace, Blockly.Xml.textToDom(blockXML));
   var numberBlock = Blockly.mainBlockSpace.getTopBlocks()[0];


### PR DESCRIPTION
Until now, `bumpNeighbours_` has only looked at opposing connections.  This PR updates the definition of "neighbors" to include situations where two blocks have an overlapping connection of the _same_ type.

In this case, since neither connection is "superior", we add new logic to determine which to bump:
1. Prioritize bumping unconnected blocks over connected blocks. 
![bump-priority-unconnected](https://user-images.githubusercontent.com/413693/41797615-915ce962-761f-11e8-9b6c-093e1813768c.gif)
![bump-priority-connected](https://user-images.githubusercontent.com/413693/41797654-c796cd18-761f-11e8-9237-6f74d4d18121.gif)

2. When both blocks are unconnected, prioritize bumping blocks lower on the screen.
![bump-priority-position](https://user-images.githubusercontent.com/413693/41797784-327338ba-7620-11e8-9f6a-0e81a822a4af.gif)