### PR TITLE
Don't fire unnecessary window "resize" events

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -270,7 +270,6 @@ Blockly.Block.prototype.initSvg = function() {
   this.setCurrentlyHidden(this.currentlyHidden_);
   this.moveToFrontOfMainCanvas_();
   this.setIsUnused();
-  this.render();
 };
 
 /**

--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -2539,12 +2539,15 @@ Blockly.Block.prototype.svgInitialized = function() {
 /**
  * Render the block.
  * Lays out and reflows a block based on its contents and settings.
+ * @param {boolean} selfOnly Whether to render only this block and NOT also
+ * its parents which in turn would trigger a window resize event. Defaults to
+ * false.
  */
-Blockly.Block.prototype.render = function() {
+Blockly.Block.prototype.render = function(selfOnly) {
   if (!this.svg_) {
     throw 'Uninitialized block cannot be rendered.  Call block.initSvg()';
   }
-  this.svg_.render();
+  this.svg_.render(selfOnly);
 };
 
 /**

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -514,10 +514,6 @@ Blockly.Flyout.prototype.show = function(xmlList) {
       // prevent the closure of the flyout if the user right-clicks on such a
       // block.
       child.isInFlyout = true;
-      // There is no good way to handle comment bubbles inside the flyout.
-      // Blocks shouldn't come with predefined comments, but someone will
-      // try this, I'm sure.  Kill the comment.
-      child.setCommentText(null);
     }
 
     block.render(true);

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -520,7 +520,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
       child.setCommentText(null);
     }
 
-    block.render();
+    block.render(true);
     this.layoutBlock_(block, cursor, gaps[i], initialX);
     // Create an invisible rectangle under the block to act as a button.  Just
     // using the block as a button is poor, since blocks have holes in them.

--- a/core/ui/contract_editor/example_view.js
+++ b/core/ui/contract_editor/example_view.js
@@ -150,7 +150,7 @@ Blockly.ExampleView.prototype.placeExampleAndGetNewY = function (
       }
       input.extraSpace = exampleMaxInputWidth - width;
       if (input.extraSpace !== originalExtraSpace) {
-        block.getSvgRenderer().render(true);
+        block.render(true);
       }
     }
 

--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -525,10 +525,10 @@ Blockly.Xml.domToBlock = function(blockSpace, xmlBlock) {
   var next = block.nextConnection && block.nextConnection.targetBlock();
   if (next) {
     // Next block in a stack needs to square off its corners.
-    // Rendering a child will render its parent.
-    next.render();
+    next.render(true);
+    block.render(true);
   } else {
-    block.render();
+    block.render(true);
   }
   return block;
 };


### PR DESCRIPTION
Reduces the time to open the "Sprites" tab of the toolbox on /p/spritelab from ~500ms to ~200ms.

**Before:**

![screen shot 2018-06-27 at 1 57 55 pm](https://user-images.githubusercontent.com/413693/42006211-61a11d3a-7a2d-11e8-9c17-b1a0327e514c.png)

**After:**

![screen shot 2018-06-27 at 5 12 24 pm](https://user-images.githubusercontent.com/413693/42006216-6661720c-7a2d-11e8-9b42-7edc8f7942a8.png)

Both graphs have a horizontal time scale of about ~570ms.