### PR TITLE
Wait to render "unused block" DOM until it's needed

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -270,7 +270,6 @@ Blockly.Block.prototype.initSvg = function() {
   this.setCurrentlyHidden(this.currentlyHidden_);
   this.moveToFrontOfMainCanvas_();
   this.setIsUnused();
-  this.render();
 };
 
 /**

--- a/core/ui/block_space/block_space.js
+++ b/core/ui/block_space/block_space.js
@@ -350,7 +350,7 @@ Blockly.BlockSpace.prototype.createDom = function() {
   Blockly.bindEvent_(this.svgBlockCanvas_, Blockly.BlockSpace.EVENTS.RUN_BUTTON_CLICKED, this, function () {
     this.getTopBlocks().forEach(function (block) {
       if (block.isUnused()) {
-        block.svg_.addUnusedFrame();
+        block.getSvgRenderer().addUnusedFrame();
       }
     });
   });

--- a/core/ui/block_space/block_space.js
+++ b/core/ui/block_space/block_space.js
@@ -347,6 +347,14 @@ Blockly.BlockSpace.prototype.createDom = function() {
   }
   this.svgDragCanvas_ = Blockly.createSvgElement('g', {'class': 'svgDragCanvas'}, Blockly.dragSvg);
 
+  Blockly.bindEvent_(this.svgBlockCanvas_, Blockly.BlockSpace.EVENTS.RUN_BUTTON_CLICKED, this, function () {
+    this.getTopBlocks().forEach(function (block) {
+      if (block.isUnused()) {
+        block.svg_.addUnusedFrame();
+      }
+    });
+  });
+
   this.fireChangeEvent();
   return this.svgGroup_;
 };

--- a/core/ui/block_svg/block_svg.js
+++ b/core/ui/block_svg/block_svg.js
@@ -522,7 +522,7 @@ BS.INNER_BOTTOM_LEFT_CORNER_HIGHLIGHT_LTR =
  * @return {Object} object with padding values for top, bottom, left, and right
  */
 Blockly.BlockSvg.prototype.getPadding = function() {
-  if (this.isUnused()) {
+  if (this.unusedSvg_) {
     return this.unusedSvg_.getPadding();
   }
   return {
@@ -562,9 +562,7 @@ Blockly.BlockSvg.prototype.dispose = function() {
   this.svgPathLight_ = null;
   this.svgPathDark_ = null;
   // dispose of children
-  if (this.isUnused()) {
-    this.unusedSvg_.dispose();
-  }
+  this.removeUnusedFrame();
   // Break circular references.
   this.block_ = null;
 };
@@ -870,9 +868,7 @@ Blockly.BlockSvg.prototype.render = function(selfOnly) {
     }
   }
 
-  if (this.isUnused()) {
-    this.unusedSvg_.render(this.svgGroup_);
-  }
+  this.removeUnusedFrame();
 };
 
 /**
@@ -1658,7 +1654,7 @@ Blockly.BlockSvg.prototype.innerTopLeftCorner = function (notchPathRight) {
 };
 
 Blockly.BlockSvg.prototype.isUnused = function () {
-  return !!this.unusedSvg_;
+  return Blockly.elementHasClass_(this.svgGroup_, 'blocklyUnused');
 };
 
 Blockly.BlockSvg.prototype.setIsUnused = function (isUnused) {
@@ -1667,12 +1663,20 @@ Blockly.BlockSvg.prototype.setIsUnused = function (isUnused) {
   } else {
     Blockly.removeClass_(this.svgGroup_, 'blocklyUnused');
   }
-  if (!isUnused && this.unusedSvg_) {
+
+  this.removeUnusedFrame();
+};
+
+Blockly.BlockSvg.prototype.addUnusedFrame = function () {
+  if (!this.unusedSvg_) {
+    this.unusedSvg_ = new Blockly.BlockSvgUnused(this);
+  }
+  this.unusedSvg_.render(this.svgGroup_);
+};
+
+Blockly.BlockSvg.prototype.removeUnusedFrame = function () {
+  if (this.unusedSvg_) {
     this.unusedSvg_.dispose();
     this.unusedSvg_ = null;
-  } else if (isUnused && !this.unusedSvg_) {
-    this.unusedSvg_ = new Blockly.BlockSvgUnused(this.block_);
   }
-
-  this.render();
 };

--- a/core/ui/block_svg/block_svg_unused.js
+++ b/core/ui/block_svg/block_svg_unused.js
@@ -135,6 +135,7 @@ Blockly.BlockSvgUnused.prototype.render = function (svgGroup) {
 
   Blockly.addClass_(this.frameGroup_, 'hidden');
   var frameGroup = this.frameGroup_;
+  // Trigger the CSS fade-in transition.
   setTimeout(function () {
     Blockly.removeClass_(frameGroup, 'hidden');
   }, 0);

--- a/core/ui/block_svg/block_svg_unused.js
+++ b/core/ui/block_svg/block_svg_unused.js
@@ -31,11 +31,6 @@ Blockly.BlockSvgUnused = function (block) {
 Blockly.BlockSvgUnused.UNUSED_BLOCK_HELP_EVENT = 'blocklyUnusedBlockHelpClicked';
 
 Blockly.BlockSvgUnused.prototype.initChildren = function () {
-
-  // Unhide when run button pressed. Save binding data so we can unbind.
-  this.bindData_ = Blockly.bindEvent_(Blockly.mainBlockSpace.getCanvas(),
-      Blockly.BlockSpace.EVENTS.RUN_BUTTON_CLICKED, this, this.unhide.bind(this));
-
   this.frameGroup_ = Blockly.createSvgElement('g', {
     'class': 'blocklyUnusedFrame'
   });
@@ -127,10 +122,6 @@ Blockly.BlockSvgUnused.prototype.bindClickEvent = function () {
   });
 };
 
-Blockly.BlockSvgUnused.prototype.unhide = function () {
-  this.frameGroup_ && Blockly.removeClass_(this.frameGroup_, 'hidden');
-};
-
 Blockly.BlockSvgUnused.prototype.render = function (svgGroup) {
 
   // Remove ourselves from the DOM and calculate the size of our
@@ -143,6 +134,10 @@ Blockly.BlockSvgUnused.prototype.render = function (svgGroup) {
   goog.dom.insertChildAt(svgGroup, this.frameGroup_, 0);
 
   Blockly.addClass_(this.frameGroup_, 'hidden');
+  var frameGroup = this.frameGroup_;
+  setTimeout(function () {
+    Blockly.removeClass_(frameGroup, 'hidden');
+  }, 0);
 
   this.bindClickEvent();
 


### PR DESCRIPTION
This is a slightly different approach to fixing the issue in PR https://github.com/code-dot-org/blockly/pull/11, to unblock PR https://github.com/code-dot-org/blockly/pull/129.

By not rendering the block in `this.setIsUnused();` we're able to postpone rendering until the full stack of blocks is built up, which will avoid any potential unwanted bumps.