### PR TITLE
Only catch errors related to malformed XML when pasting

### DIFF
--- a/core/ui/block_space/block_space_editor.js
+++ b/core/ui/block_space/block_space_editor.js
@@ -763,7 +763,11 @@ Blockly.BlockSpaceEditor.prototype.onPaste_ = function(e) {
   try {
     var xml = Blockly.Xml.textToDom(e.clipboardData.getData('text/xml') || e.clipboardData.getData('text/plain'));
     Blockly.focusedBlockSpace.paste(xml);
-  } catch (_) { }
+  } catch (e) {
+    if (!/did not obtain a valid XML tree/.test(e)) {
+      throw e;
+    }
+  }
 };
 
 /**

--- a/tests/block_space_test.js
+++ b/tests/block_space_test.js
@@ -284,3 +284,51 @@ function test_blockSpaceWithLimitedQuantitiesOfBlocks() {
 
   goog.dom.removeNode(container);
 }
+
+function test_paste() {
+  var container = Blockly.Test.initializeBlockSpaceEditor();
+  Blockly.focusedBlockSpace = Blockly.mainBlockSpace;
+
+  function createMockClipboardEvent(type, data) {
+    return {
+      type: type,
+      clipboardData: {
+        getData: function () {
+          return data;
+        }
+      }
+    };
+  }
+
+  // Ignores malformed XML on the clipboard.
+  Blockly.mainBlockSpaceEditor.onPaste_(createMockClipboardEvent('paste', 'not real XML'));
+  assertEquals('Ignores malformed XML on the clipboard', 0, Blockly.mainBlockSpace.getTopBlocks().length);
+
+  // Can paste a block.
+  Blockly.mainBlockSpaceEditor.onPaste_(createMockClipboardEvent('paste', '<xml><block type="math_number"/></xml>'));
+  var topBlocks = Blockly.mainBlockSpace.getTopBlocks();
+  assertEquals('Can paste a block', 1, topBlocks.length);
+  assertEquals('math_number', topBlocks[0].type);
+
+  // Doesn't swallow errors not related to XML formatting.
+  var xml = '<xml>' +
+    '<block type="controls_repeat_ext">' +
+      '<value name="TIMES">' +
+        '<block type="math_number">' +
+          '<title name="NUM">10</title>' +
+        '</block>' +
+      '</value>' +
+      '<value name="TIMES">' +
+        '<block type="math_number">' +
+          '<title name="NUM">20</title>' +
+        '</block>' +
+      '</value>' +
+    '</block>' +
+  '</xml>';
+  var mockEvent = createMockClipboardEvent('paste', xml);
+  assertThrows(function () {
+    Blockly.mainBlockSpaceEditor.onPaste_(mockEvent);
+  });
+
+  goog.dom.removeNode(container);
+}


### PR DESCRIPTION
Re-throw other errors so they don't get lost.