### PR TITLE
Add a codecov config file

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+  branch: master


### PR DESCRIPTION
Codecov isn't picking up on the fact that this repo's master branch is `master`, not `staging`. Let's see if specifying the master branch in a config file fixes that.