### PR TITLE
Still load node_modules cache on package.json mismatch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
     - restore_cache:
         keys:
         - v3-dep-{{ checksum "package.json" }}
+        - v3-dep-
     - run: npm install
     - save_cache:
         key: v3-dep-{{ checksum "package.json" }}


### PR DESCRIPTION
Circle builds have been slower than normal because of all the package.json changes. If it changes, it still speeds things up if we load the most recent node_modules cache.