### PR TITLE
Fix goog.Timer

### DIFF
--- a/core/module.js
+++ b/core/module.js
@@ -1,4 +1,7 @@
 goog.require('Blockly');
 goog.provide('BlocklyModule');
 
+goog.require('goog.Timer');
+goog.Timer.defaultTimerObject = window;
+
 module.exports = Blockly;

--- a/core/module.js
+++ b/core/module.js
@@ -1,6 +1,12 @@
 goog.require('Blockly');
 goog.provide('BlocklyModule');
 
+// Fix goog.Timer
+// goog.global is set to the window object in most places where the closure
+// library is used, but since we build under webpack that is not the case for
+// us. goog.Timer.defaultTimerObject defaults to goog.global, but we need to
+// manually set it to the window object so that it has setTimeout, setInterval,
+// etc.
 goog.require('goog.Timer');
 goog.Timer.defaultTimerObject = window;
 


### PR DESCRIPTION
I removed all the direct uses of goog.Timer, but we still use it indirectly in the contract editor through `goog.ui.MenuButton`. Rewriting the contract editor to no longer use that would be a lot more work than just correctly setting the `goog.Timer`'s `defaultTimerObject`.