### PR TITLE
Disable topLevelAutopopulate if toolbox has categories

### DIFF
--- a/core/initialization/inject.js
+++ b/core/initialization/inject.js
@@ -140,6 +140,11 @@ Blockly.parseOptions_ = function(options) {
     options['hasVerticalScrollbars'] = true;
     options['hasHorizontalScrollbars'] = true;
   }
+  var topLevelProcedureAutopopulate = options['topLevelProcedureAutopopulate'] || false;
+  if (topLevelProcedureAutopopulate && hasCategories) {
+    console.warn("Don't use topLevelProcedureAutopopulate with a categorized toolbox");
+    topLevelProcedureAutopopulate = false;
+  }
   return {
     RTL: !!options['rtl'],
     collapse: hasCollapse,
@@ -160,7 +165,7 @@ Blockly.parseOptions_ = function(options) {
     disableParamEditing: options['disableParamEditing'] || false,
     disableVariableEditing: options['disableVariableEditing'] || false,
     disableProcedureAutopopulate: options['disableProcedureAutopopulate'] || false,
-    topLevelProcedureAutopopulate: options['topLevelProcedureAutopopulate'] || false,
+    topLevelProcedureAutopopulate: topLevelProcedureAutopopulate,
     useModalFunctionEditor: options['useModalFunctionEditor'] || false,
     useContractEditor: options['useContractEditor'] || false,
     disableExamples: options['disableExamples'] || false,

--- a/tests/blockly_test.js
+++ b/tests/blockly_test.js
@@ -263,3 +263,25 @@ function test_addToNonZeroSides() {
   assert(goog.math.Box.equals(expectedBox, actualBox));
 }
 
+function test_parseOptions_noTopLevelProcedureAutopopulate() {
+  var options = Blockly.parseOptions_({
+    toolbox: '<xml><block/></xml>',
+  });
+  assert(!options.topLevelProcedureAutopopulate);
+}
+
+function test_parseOptions_topLevelProcedureAutopopulate() {
+  var options = Blockly.parseOptions_({
+    toolbox: '<xml><block/></xml>',
+    topLevelProcedureAutopopulate: true,
+  });
+  assert(options.topLevelProcedureAutopopulate);
+}
+
+function test_parseOptions_topLevelProcedureAutopopulateWithCategories() {
+  var options = Blockly.parseOptions_({
+    toolbox: '<xml><category name="CAT"><block/></category></xml>',
+    topLevelProcedureAutopopulate: true,
+  });
+  assert(!options.topLevelProcedureAutopopulate);
+}


### PR DESCRIPTION
It doesn't make sense to enable this option if the toolbox has categories, and that invalid combination led to a confusing bug recently.