### PR TITLE
Add editor methods to lock/unlock block movement

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1557,7 +1557,8 @@ Blockly.Block.prototype.shouldBeGrayedOut = function() {
  * @return {boolean} True if movable.
  */
 Blockly.Block.prototype.isMovable = function() {
-  return this.movable_ && !this.blockSpace.isReadOnly();
+  return this.movable_ && !this.blockSpace.isReadOnly() &&
+    !this.blockSpace.isMovementLocked();
 };
 
 /**

--- a/core/ui/block_space/block_space.js
+++ b/core/ui/block_space/block_space.js
@@ -284,6 +284,10 @@ Blockly.BlockSpace.prototype.isReadOnly = function() {
   return (Blockly.readOnly || this.blockSpaceEditor.isReadOnly());
 };
 
+Blockly.BlockSpace.prototype.isMovementLocked = function() {
+  return this.blockSpaceEditor.isMovementLocked();
+};
+
 /**
  * Sets up debug console logging for events
  */

--- a/core/ui/block_space/block_space_editor.js
+++ b/core/ui/block_space/block_space_editor.js
@@ -77,6 +77,7 @@ Blockly.BlockSpaceEditor = function(container, opt_options) {
   this.readOnly_ = !!opt_options.readOnly;
   this.noScrolling_ = !!opt_options.noScrolling;
   this.inline_ = !!opt_options.inline;
+  this.movementLocked_ = false;
 
   /**
    * @type {Blockly.BlockSpace}
@@ -1016,6 +1017,21 @@ Blockly.BlockSpaceEditor.prototype.addUnusedBlocksHelpListener = function(func) 
  */
 Blockly.BlockSpaceEditor.prototype.isReadOnly = function() {
   return (Blockly.readOnly || this.readOnly_);
+};
+
+/**
+ * Disable block movement, but unlike readonly mode still allow field editing.
+ */
+Blockly.BlockSpaceEditor.prototype.lockMovement = function() {
+  this.movementLocked_ = true;
+};
+
+Blockly.BlockSpaceEditor.prototype.unlockMovement = function() {
+  this.movementLocked_ = false;
+};
+
+Blockly.BlockSpaceEditor.prototype.isMovementLocked = function() {
+  return this.movementLocked_;
 };
 
 /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const DEV = process.env.DEV;
 
 const compilerOptions = {
   jar: 'node_modules/google-closure-compiler/compiler.jar',
-  compilation_level: DEV ? 'WHITESPACE_ONLY' : 'SIMPLE',
+  compilation_level: 'SIMPLE',
   entry_point: 'BlocklyModule',
   only_closure_dependencies: true,
   create_source_map: true,


### PR DESCRIPTION
This adds lock/unlock movement methods to the block space editor to support limited autorun in https://github.com/code-dot-org/code-dot-org/pull/24196.