### PR TITLE
Fix movement locking bug

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -708,7 +708,9 @@ Blockly.Block.prototype.onMouseDown_ = function(e) {
     if (Blockly.editBlocks) {
       this.showContextMenu_(e);
     }
-  } else if (!this.isMovable() || !this.canDisconnectFromParent()) {
+  } else if (this.blockSpace.isMovementLocked() ||
+      !this.isMovable() ||
+      !this.canDisconnectFromParent()) {
     // Allow unmovable blocks to be selected and context menued, but not
     // dragged.  Let this event bubble up to document, so the blockSpace may be
     // dragged instead.
@@ -1557,8 +1559,7 @@ Blockly.Block.prototype.shouldBeGrayedOut = function() {
  * @return {boolean} True if movable.
  */
 Blockly.Block.prototype.isMovable = function() {
-  return this.movable_ && !this.blockSpace.isReadOnly() &&
-    !this.blockSpace.isMovementLocked();
+  return this.movable_ && !this.blockSpace.isReadOnly();
 };
 
 /**

--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1555,7 +1555,9 @@ Blockly.Block.prototype.shouldBeGrayedOut = function() {
 };
 
 /**
- * Get whether this block is movable or not.
+ * Get whether this block is movable or not. Note that this can still return
+ * true if block movement is locked for the entire blockSpace, check
+ * blockSpaceEditor.isMovementLocked() separately.
  * @return {boolean} True if movable.
  */
 Blockly.Block.prototype.isMovable = function() {

--- a/tests/block_space_test.js
+++ b/tests/block_space_test.js
@@ -332,3 +332,22 @@ function test_paste() {
 
   goog.dom.removeNode(container);
 }
+
+function test_locked_serialization() {
+  var container = Blockly.Test.initializeBlockSpaceEditor();
+  var blockXML = `<xml>
+  <block type="text_print"></block>
+  <block type="text">
+    <title name="TEXT"></title>
+  </block>
+</xml>`;
+  Blockly.Xml.domToBlockSpace(
+    Blockly.mainBlockSpace, Blockly.Xml.textToDom(blockXML));
+
+  Blockly.mainBlockSpace.blockSpaceEditor.lockMovement();
+  var newBlockXml = Blockly.Xml.domToPrettyText(
+    Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace));
+
+  assertEquals('Block Xml is not changed by locking movement',
+    blockXML, newBlockXml);
+}


### PR DESCRIPTION
There's a bug with limited autorun in which the blocks becoming permanently immovable if your code is saved while block movement was locked. That's because `block.isMovable()` is used to determine the 'movable' attribute for the block's xml, and that method returns false if movement is locked in the block space. The next time you load the puzzle, the blocks will be initialized with `movable="false"` and you won't be able to move any of your blocks again without restarting.

This PR moves the `isMovementLocked()` check outside of `block.isMovable()` to the mousedown handler.