### PR TITLE
Update infinite loop error to an Error object

### DIFF
--- a/generators/javascript/loops.js
+++ b/generators/javascript/loops.js
@@ -117,7 +117,7 @@ Blockly.JavaScript.controls_for = function() {
       code += (up ? ' += ' : ' -= ') + step;
       if (step === 0) {
         // guaranteed to loop infinitely if we're looping with step
-        branch = '  throw Infinity;\n' + branch;
+        branch = '  throw new Error("Infinity");\n' + branch;
       }
     }
     code += ') {\n' + branch + '}\n';


### PR DESCRIPTION
For consistency, I'm updating this to match the error thrown for infinite loops here: https://github.com/code-dot-org/code-dot-org/blob/7e2fcc28fbb791f0dd594c8b6e6192bca6f9a277/apps/src/lib/tools/jsinterpreter/CustomMarshalingInterpreter.js#L11