### PR TITLE
Don't intercept copy event if text is selected

### DIFF
--- a/core/ui/block_space/block_space_editor.js
+++ b/core/ui/block_space/block_space_editor.js
@@ -745,7 +745,7 @@ Blockly.BlockSpaceEditor.prototype.onKeyDown_ = function(e) {
  * @private
  */
 Blockly.BlockSpaceEditor.prototype.onCutCopy_ = function(e) {
-  if (Blockly.selected) {
+  if (Blockly.selected && !window.getSelection().toString()) {
     e.clipboardData.setData('text/xml', Blockly.clipboard_);
     e.preventDefault();
 


### PR DESCRIPTION
This fixes the share link copying bug reported on https://studio.code.org/s/coursee-2018/stage/13/puzzle/10. (If you click run+finish and try to copy the share URL, it doesn't work)

The problem was that if a block is highlighted (e.g. because the program was just running, and we're in an app that highlights blocks as they run), the blockly code here intercepts the copy event and prevents you from copying anything but the selected block to the clipboard.

I tried to fix this by looking at the currently focused element and only copying the block if you were just touching the workspace, but for some reason the blockly workspace doesn't become the focused element when you interact with it (`document.activeElement` points to `document.body`) so this broke block copying.

My solution is to only copy a block to the clipboard if there's no text selected elsewhere on the page. If there is selected text, the blockly copy handler does nothing the the text gets copied like normal. I'm not sure if this is a sloppy hack or if it gives us exactly the behavior we want (or both!).