### PR TITLE
FieldDropdown#setConfig should support non-numeric options

### DIFF
--- a/core/ui/fields/field_dropdown.js
+++ b/core/ui/fields/field_dropdown.js
@@ -285,9 +285,12 @@ Blockly.FieldDropdown.prototype.setToFirstValue_ = function () {
 Blockly.FieldDropdown.prototype.setConfig = function(configString) {
   this.config = configString; // Store for later block -> XML copying
 
-  var options = (configString || '').split(',');
+  var options = Blockly.printerRangeToNumbers(configString);
   if (options.length === 0) {
-    return;
+    options = (configString || '').split(',');
+    if (options.length === 0) {
+      return;
+    }
   }
 
   var existingOptions = {};

--- a/core/ui/fields/field_dropdown.js
+++ b/core/ui/fields/field_dropdown.js
@@ -277,19 +277,30 @@ Blockly.FieldDropdown.prototype.setToFirstValue_ = function () {
 };
 
 /**
- * Sets dropdown options to a set of numbers defined by the configString
- * @param configString printer-range style string, e.g., "1-5,8,15"
+ * Sets dropdown options to a set of numbers defined by the configString.
+ * @param configString Option values to show. If the value is present in the
+ *   block definition, use the corresponding option. Otherwise add a new option
+ *   with the same value and display option.
  */
 Blockly.FieldDropdown.prototype.setConfig = function(configString) {
   this.config = configString; // Store for later block -> XML copying
 
-  var numberOptions = Blockly.printerRangeToNumbers(configString);
-  if (numberOptions.length === 0) {
+  var options = (configString || '').split(',');
+  if (options.length === 0) {
     return;
   }
 
-  this.menuGenerator_ = goog.array.map(numberOptions, function(item) {
-    return [item.toString(), item.toString()];
+  var existingOptions = {};
+  goog.array.forEach(this.getOptions(), function (entry) {
+    existingOptions[entry[1]] = entry[0];
+  });
+
+  this.menuGenerator_ = goog.array.map(options, function (option) {
+    var existing = existingOptions[option];
+    if (existing) {
+      return [existing.toString(), option.toString()];
+    }
+    return [option.toString(), option.toString()];
   });
 
   this.setToFirstValue_();

--- a/tests/fields_test.js
+++ b/tests/fields_test.js
@@ -79,7 +79,10 @@ function test_field_reposition_on_scroll() {
 
 function test_dropdown_options() {
   var dropdown = new Blockly.FieldDropdown([['Foo 123', 'foo'], ['Bar 456', 'bar']]);
-  dropdown.setConfig('foo,abc,zzz');
 
-  assert(goog.array.equals([['Foo 123', 'foo'], ['abc', 'abc'], ['zzz', 'zzz']], dropdown.getOptions()));
+  dropdown.setConfig('foo,abc,zzz');
+  assert(goog.array.equals(['Foo 123', 'foo', 'abc', 'abc', 'zzz', 'zzz'], goog.array.flatten(dropdown.getOptions())));
+
+  dropdown.setConfig('5-7,10');
+  assert(goog.array.equals(["5", "5", "6", "6", "7", "7", "10", "10"], goog.array.flatten(dropdown.getOptions())));
 }

--- a/tests/fields_test.js
+++ b/tests/fields_test.js
@@ -76,3 +76,10 @@ function test_field_reposition_on_scroll() {
 
   goog.dom.removeNode(containerDiv);
 }
+
+function test_dropdown_options() {
+  var dropdown = new Blockly.FieldDropdown([['Foo 123', 'foo'], ['Bar 456', 'bar']]);
+  dropdown.setConfig('foo,abc,zzz');
+
+  assert(goog.array.equals([['Foo 123', 'foo'], ['abc', 'abc'], ['zzz', 'zzz']], dropdown.getOptions()));
+}


### PR DESCRIPTION
Re-use the provided display name for a given option, if available.

```xml
<xml>
  <block type="Dancelab_changeMoveLR">
    <title name="SPRITE">dancer1</title>
    <title name="MOVE" config="MOVES.DoubleJam,MOVES.Floss,MOVES.Clown">MOVES.Floss</title>
    <title name="DIR">-1</title>
  </block>
</xml>
```

Produces:

![image](https://user-images.githubusercontent.com/413693/46226249-8864ca80-c310-11e8-951a-a27e630e33e2.png)