### PR TITLE
Don't skip `setIsUnused` when main workspace is readonly

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1817,7 +1817,6 @@ Blockly.Block.prototype.setIsUnused = function(isUnused) {
         this.isUserVisible() &&
         this.type !== 'functional_definition' &&
         Blockly.mainBlockSpace &&
-        Blockly.mainBlockSpace.isReadOnly() === false &&
         Blockly.mainBlockSpace.isTopBlock(this);
   }
   if (Blockly.showUnusedBlocks && isUnused !== this.svg_.isUnused()) {


### PR DESCRIPTION
Fixes https://github.com/code-dot-org/dance-party/issues/417, generation of code for non-top blocks on share pages.

Originally added in https://github.com/code-dot-org/code-dot-org/commit/df02581e0c3e3b2fa14f068ed942ec9f3013c6f3, @Hamms can you provide more context for why this case was excluded originally?