### PR TITLE
Increase the dropdown height to enable a "peek" at the next option again

### DIFF
--- a/core/ui/fields/field_dropdown.js
+++ b/core/ui/fields/field_dropdown.js
@@ -135,7 +135,7 @@ Blockly.FieldDropdown.prototype.showEditor_ = function(container) {
     this.sourceBlock_.getSaturation() * 100 + '%, ' +
     this.sourceBlock_.getValue() * 100 + '%' + ', 0.5)';
   menuDom.style.overflowY = "auto";
-  menuDom.style["max-height"] = "250px";
+  menuDom.style["max-height"] = "265px";
 
   this.positionWidgetDiv();
 


### PR DESCRIPTION
[Years ago](https://github.com/code-dot-org/code-dot-org/pull/1542) I set the `max-height` of a blockly dropdown to be `250px` so that we would get a "peek" at the next option, if there were one, so that users would know it was scrollable on systems that don't have scrollbars.

Over time, this size seems to no longer show a peek, and so here's a change to bump it to `265px`:

![screenshot 2018-11-20 09 02 47](https://user-images.githubusercontent.com/2205926/48738525-6733b100-eca5-11e8-98cd-86ad94d58517.png)

This change has broad impact, so we should consider its adoption carefully.

This fixes https://github.com/code-dot-org/dance-party/issues/260.
