### PR TITLE
Check block connectivity rules before superiority

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1355,17 +1355,17 @@ Blockly.Block.prototype.bumpNeighbours = function() {
       }
 
       var bumpOther = false;
-      // When bumping connections of opposite types, always bump the inferior block.
-      if (connection.type !== otherConnection.type) {
-        bumpOther = connection.isSuperior();
       // If one is connected and the other is unconnected, always bump the
       // unconnected block.
-      } else if (connection.targetConnection && !otherConnection.targetConnection) {
+      if (connection.targetConnection && !otherConnection.targetConnection) {
         bumpOther = true;
       } else if (!connection.targetConnection && otherConnection.targetConnection) {
         bumpOther = false;
-      // Otherwise bump the block that is lower on the screen.
+      } else if (connection.type !== otherConnection.type) {
+        // When bumping connections of opposite types, always bump the inferior block.
+        bumpOther = connection.isSuperior();
       } else {
+        // Otherwise bump the block that is lower on the screen.
         var rootY = rootBlock.getRelativeToSurfaceXY().y;
         var otherY = otherRootBlock.getRelativeToSurfaceXY().y;
         bumpOther = rootY < otherY;


### PR DESCRIPTION
Will fix https://github.com/code-dot-org/dance-party/issues/62

There's a subtle case we're guarding against here and probably a deeper fix would be good, but as far as I can tell this does solve the case we care about.

An unconnected block (after paste) could bump a large section of connected blocks, which seems like behavior we never want to use. Now we use the new rules checking whether blocks are connected before bumping first, which gives nicer behavior.

Worse, in a few cases this could lead to an infinite loop of block-bumping:

![infinibump](https://user-images.githubusercontent.com/1615761/48866147-9ff78700-ed86-11e8-912f-edec154b702a.gif)

I managed to write a unit test that reproduces this behavior with stock blocks, and after this fix it no longer does:

![peek 2018-11-21 14-49](https://user-images.githubusercontent.com/1615761/48872159-c6c0b800-ed9c-11e8-9dfd-e2430c6f97df.gif)


The infinite loop potential was introduced in https://github.com/code-dot-org/blockly/pull/128 so I checked to make sure I'm preserving the desired new behaviors from that PR.

![peek 2018-11-21 14-46](https://user-images.githubusercontent.com/1615761/48872075-6af62f00-ed9c-11e8-88bf-3f699d18bd79.gif)

And here's the fix working with the known broken case in dance-party:

![peek 2018-11-21 14-55](https://user-images.githubusercontent.com/1615761/48872346-8ada2280-ed9d-11e8-92f2-74d3048a6797.gif)
