### PR TITLE
don't swallow backspace/delete on phone inputs

### DIFF
--- a/core/utils/utils.js
+++ b/core/utils/utils.js
@@ -624,12 +624,13 @@ Blockly.getUID = function() {
 };
 
 /**
- * Is this event targeting a text input widget?
+ * Is this event targeting a text or phone input widget?
  * @param {!Event} e An event.
- * @return {boolean} True if text or textarea input.
+ * @return {boolean}
  */
 Blockly.isTargetInput = function (e) {
-  return e.target.type == 'textarea' || e.target.type == 'text';
+  return e.target.type == 'textarea' || e.target.type == 'text' ||
+    e.target.type == 'tel';
 };
 
 /**


### PR DESCRIPTION
fixes (5) from https://github.com/code-dot-org/dance-party/issues/462 . applies to any finish dialog on blockly levels, including /s/dance, /s/artist, and many other HoC scripts.