### PR TITLE
Rect dropdown and img dropdown allow function to update choices

### DIFF
--- a/core/ui/fields/field_image_dropdown.js
+++ b/core/ui/fields/field_image_dropdown.js
@@ -31,17 +31,19 @@ goog.require('Blockly.ImageDimensionCache');
  * Class for a rectangular image dropdown field.
  * By default, will auto-size SVG block preview and HTML dropdown previews to image dimensions,
  * specifying a width / height will make the images scale to auto-fill
- * @param {!Array.<string>} choices An array of choices for a dropdown list, each choice is a
- *                                  tuple of [image path, value]
+ * @param {(!Array.<string>|!Function)} menuGenerator An array of options
+ *     for a dropdown list, where each choice is a tuple of [image path, value],
+ *     or a function which generates these options
  * @extends {Blockly.FieldRectangularDropdown}
  * @constructor
  * @param width force the dropdown to use a given width
  * @param height force the dropdown to use a given height
  */
-Blockly.FieldImageDropdown = function(choices, width, height) {
+Blockly.FieldImageDropdown = function(menuGenerator, width, height) {
   this.width_ = width;
   this.height_ = height;
-  Blockly.FieldImageDropdown.superClass_.constructor.call(this, choices);
+  this.menuGenerator_ = menuGenerator;
+  Blockly.FieldImageDropdown.superClass_.constructor.call(this, menuGenerator);
   if (this.hasForcedDimensions_()) {
     this.updateDimensions_(this.width_, this.height_);
   }

--- a/core/ui/fields/field_rectangular_dropdown.js
+++ b/core/ui/fields/field_rectangular_dropdown.js
@@ -29,14 +29,16 @@ goog.require('Blockly.ImageDimensionCache');
 
 /**
  * Class for a rectangular dropdown field.
- * @param {!Array.<string>} choices An array of choices for a dropdown list, each choice is a
- *                                  tuple of [image location, value]
+ * @param {(!Array.<string>|!Function)} menuGenerator An array of choices
+ *     for a dropdown list, where each choice is a tuple of [image location, value],
+ *     or a function which generates these options
  * @extends {Blockly.Field}
  * @constructor
  */
-Blockly.FieldRectangularDropdown = function(choices) {
-  this.choices_ = choices;
-  var firstTuple = this.choices_[0];
+Blockly.FieldRectangularDropdown = function(menuGenerator) {
+  this.menuGenerator_ = menuGenerator;
+  let choices = this.getOptions();
+  var firstTuple = choices[0];
   this.value_ = firstTuple[Blockly.FieldRectangularDropdown.TUPLE_VALUE_INDEX];
   var firstPreviewData = firstTuple[Blockly.FieldRectangularDropdown.TUPLE_PREVIEW_DATA_INDEX];
 
@@ -69,7 +71,10 @@ Blockly.FieldRectangularDropdown.prototype.CURSOR = 'default';
 Blockly.FieldRectangularDropdown.prototype.EDITABLE = true;
 
 Blockly.FieldRectangularDropdown.prototype.getOptions = function() {
-  return this.choices_;
+  if (goog.isFunction(this.menuGenerator_)) {
+    return this.menuGenerator_.call(this);
+  }
+  return /** @type {!Array.<!Array.<string>>} */ (this.menuGenerator_);
 };
 
 Blockly.FieldRectangularDropdown.prototype.buildDOMElements_ = function() {
@@ -159,7 +164,7 @@ Blockly.FieldRectangularDropdown.prototype.setArrowDirection_ = function(up) {
 
 Blockly.FieldRectangularDropdown.prototype.showMenu_ = function() {
   this.showWidgetDiv_();
-  this.menu_ = this.createMenuWithChoices_(this.choices_);
+  this.menu_ = this.createMenuWithChoices_(this.getOptions());
   goog.events.listen(this.menu_, goog.ui.Component.EventType.ACTION, this.generateMenuItemSelectedHandler_());
   this.addPositionAndShowMenu(this.menu_);
   this.pointArrowUp_();
@@ -331,7 +336,7 @@ Blockly.FieldRectangularDropdown.prototype.getCurrentPreviewData_ = function() {
 };
 
 Blockly.FieldRectangularDropdown.prototype.getPreviewDataForValue_ = function(value) {
-  var choices = this.choices_;
+  var choices = this.getOptions();
   for (var x = 0; x < choices.length; x++) {
     if (choices[x][Blockly.FieldRectangularDropdown.TUPLE_VALUE_INDEX] == value) {
       return choices[x][Blockly.FieldRectangularDropdown.TUPLE_PREVIEW_DATA_INDEX];


### PR DESCRIPTION
Sprite costume tab uses image dropdown to popular the menu. As students are creating their own costumes, we want this dropdown to reflect the student's updates. Here, we update the blockly code that populates the options in those dropdowns (image dropdown extends rectangular dropdown), by allowing the array of choices, as previous used, or a function which will fetch the updated values.