### PR TITLE
Allow buttons in dropdowns

### DIFF
--- a/core/ui/fields/field_image_dropdown.js
+++ b/core/ui/fields/field_image_dropdown.js
@@ -39,11 +39,11 @@ goog.require('Blockly.ImageDimensionCache');
  * @param width force the dropdown to use a given width
  * @param height force the dropdown to use a given height
  */
-Blockly.FieldImageDropdown = function(menuGenerator, width, height) {
+Blockly.FieldImageDropdown = function(menuGenerator, width, height, button) {
   this.width_ = width;
   this.height_ = height;
   this.menuGenerator_ = menuGenerator;
-  Blockly.FieldImageDropdown.superClass_.constructor.call(this, menuGenerator);
+  Blockly.FieldImageDropdown.superClass_.constructor.call(this, menuGenerator, button);
   if (this.hasForcedDimensions_()) {
     this.updateDimensions_(this.width_, this.height_);
   }

--- a/core/ui/fields/field_image_dropdown.js
+++ b/core/ui/fields/field_image_dropdown.js
@@ -38,12 +38,15 @@ goog.require('Blockly.ImageDimensionCache');
  * @constructor
  * @param width force the dropdown to use a given width
  * @param height force the dropdown to use a given height
+ * @param {[Object]} buttons An array of object representing the text and
+ *     actions associated with buttons to be displayed at the bottom of the
+ *     dropdown list
  */
-Blockly.FieldImageDropdown = function(menuGenerator, width, height, button) {
+Blockly.FieldImageDropdown = function(menuGenerator, width, height, buttons) {
   this.width_ = width;
   this.height_ = height;
   this.menuGenerator_ = menuGenerator;
-  Blockly.FieldImageDropdown.superClass_.constructor.call(this, menuGenerator, button);
+  Blockly.FieldImageDropdown.superClass_.constructor.call(this, menuGenerator, buttons);
   if (this.hasForcedDimensions_()) {
     this.updateDimensions_(this.width_, this.height_);
   }

--- a/core/ui/fields/field_rectangular_dropdown.js
+++ b/core/ui/fields/field_rectangular_dropdown.js
@@ -35,10 +35,10 @@ goog.require('Blockly.ImageDimensionCache');
  * @extends {Blockly.Field}
  * @constructor
  */
-Blockly.FieldRectangularDropdown = function(menuGenerator, button) {
+Blockly.FieldRectangularDropdown = function(menuGenerator, buttons) {
   this.menuGenerator_ = menuGenerator;
   let choices = this.getOptions();
-  this.button_ = button;
+  this.buttons_ = buttons;
   var firstTuple = choices[0];
   this.value_ = firstTuple[Blockly.FieldRectangularDropdown.TUPLE_VALUE_INDEX];
   var firstPreviewData = firstTuple[Blockly.FieldRectangularDropdown.TUPLE_PREVIEW_DATA_INDEX];
@@ -167,8 +167,10 @@ Blockly.FieldRectangularDropdown.prototype.showMenu_ = function() {
   this.showWidgetDiv_();
   this.menu_ = this.createMenuWithChoices_(this.getOptions());
   goog.events.listen(this.menu_, goog.ui.Component.EventType.ACTION, this.generateMenuItemSelectedHandler_());
-  if (this.button_){
-    this.addMenuButton_(this.button_);
+  if (this.buttons_){
+    for (let button of this.buttons_){
+      this.addMenuButton_(button);
+    }
   }
   this.addPositionAndShowMenu(this.menu_);
   this.pointArrowUp_();

--- a/core/ui/fields/field_rectangular_dropdown.js
+++ b/core/ui/fields/field_rectangular_dropdown.js
@@ -178,11 +178,14 @@ Blockly.FieldRectangularDropdown.prototype.showMenu_ = function() {
 
 Blockly.FieldRectangularDropdown.prototype.addMenuButton_ = function(buttonData){
   let button = new goog.ui.Button(buttonData.text);
-  goog.events.listen(button, goog.ui.Component.EventType.ACTION, buttonData.action);
+  this.menuButtonListenKey_ = goog.events.listen(button, goog.ui.Component.EventType.ACTION, buttonData.action);
   this.menu_.addItem(button);
 };
 
 Blockly.FieldRectangularDropdown.prototype.hideMenu_ = function() {
+  if (this.menuButtonListenKey_) {
+    goog.events.unlistenByKey(this.menuButtonListenKey_);
+  }
   this.pointArrowDown_();
 };
 
@@ -226,7 +229,7 @@ Blockly.FieldRectangularDropdown.prototype.generateMenuItemSelectedHandler_ = fu
     var menuItem = googMenuElement.target;
     if (menuItem) {
       var value = menuItem.getValue();
-      if (value) {
+      if (value !== null && value !== undefined) {
         fieldRectanglularDropdown.setValue(value);
       }
     }

--- a/core/ui/fields/field_rectangular_dropdown.js
+++ b/core/ui/fields/field_rectangular_dropdown.js
@@ -35,9 +35,10 @@ goog.require('Blockly.ImageDimensionCache');
  * @extends {Blockly.Field}
  * @constructor
  */
-Blockly.FieldRectangularDropdown = function(menuGenerator) {
+Blockly.FieldRectangularDropdown = function(menuGenerator, button) {
   this.menuGenerator_ = menuGenerator;
   let choices = this.getOptions();
+  this.button_ = button;
   var firstTuple = choices[0];
   this.value_ = firstTuple[Blockly.FieldRectangularDropdown.TUPLE_VALUE_INDEX];
   var firstPreviewData = firstTuple[Blockly.FieldRectangularDropdown.TUPLE_PREVIEW_DATA_INDEX];
@@ -166,8 +167,15 @@ Blockly.FieldRectangularDropdown.prototype.showMenu_ = function() {
   this.showWidgetDiv_();
   this.menu_ = this.createMenuWithChoices_(this.getOptions());
   goog.events.listen(this.menu_, goog.ui.Component.EventType.ACTION, this.generateMenuItemSelectedHandler_());
+  this.addMenuButton_(this.button_);
   this.addPositionAndShowMenu(this.menu_);
   this.pointArrowUp_();
+};
+
+Blockly.FieldRectangularDropdown.prototype.addMenuButton_ = function(buttonData){
+  let button = new goog.ui.Button(buttonData.text);
+  goog.events.listen(button, goog.ui.Component.EventType.ACTION, buttonData.action);
+  this.menu_.addItem(button);
 };
 
 Blockly.FieldRectangularDropdown.prototype.hideMenu_ = function() {
@@ -214,7 +222,7 @@ Blockly.FieldRectangularDropdown.prototype.generateMenuItemSelectedHandler_ = fu
     var menuItem = googMenuElement.target;
     if (menuItem) {
       var value = menuItem.getValue();
-      if (value !== null) {
+      if (value !== null && value !== undefined) {
         fieldRectanglularDropdown.setValue(value);
       }
     }

--- a/core/ui/fields/field_rectangular_dropdown.js
+++ b/core/ui/fields/field_rectangular_dropdown.js
@@ -167,7 +167,9 @@ Blockly.FieldRectangularDropdown.prototype.showMenu_ = function() {
   this.showWidgetDiv_();
   this.menu_ = this.createMenuWithChoices_(this.getOptions());
   goog.events.listen(this.menu_, goog.ui.Component.EventType.ACTION, this.generateMenuItemSelectedHandler_());
-  this.addMenuButton_(this.button_);
+  if (this.button_){
+    this.addMenuButton_(this.button_);
+  }
   this.addPositionAndShowMenu(this.menu_);
   this.pointArrowUp_();
 };

--- a/core/ui/fields/field_rectangular_dropdown.js
+++ b/core/ui/fields/field_rectangular_dropdown.js
@@ -224,7 +224,7 @@ Blockly.FieldRectangularDropdown.prototype.generateMenuItemSelectedHandler_ = fu
     var menuItem = googMenuElement.target;
     if (menuItem) {
       var value = menuItem.getValue();
-      if (value !== null && value !== undefined) {
+      if (value) {
         fieldRectanglularDropdown.setValue(value);
       }
     }

--- a/tests/fields_test.js
+++ b/tests/fields_test.js
@@ -80,6 +80,8 @@ function test_field_reposition_on_scroll() {
 function test_dropdown_options() {
   var dropdown = new Blockly.FieldDropdown([['Foo 123', 'foo'], ['Bar 456', 'bar']]);
 
+  console.log("");
+
   dropdown.setConfig('foo,abc,zzz');
   assert(goog.array.equals(['Foo 123', 'foo', 'abc', 'abc', 'zzz', 'zzz'], goog.array.flatten(dropdown.getOptions())));
 
@@ -88,6 +90,32 @@ function test_dropdown_options() {
 
   dropdown.setConfig('5-7,10');
   assert(goog.array.equals(["5", "5", "6", "6", "7", "7", "10", "10"], goog.array.flatten(dropdown.getOptions())));
+}
+
+function test_image_dropdown_menu_button() {
+  // Set up blockspace and button with image dropdown
+  var blockSpace = Blockly.mainBlockSpace;
+  var imgDropdown = new Blockly.FieldImageDropdown([['Foo 123', 'foo'], ['Bar 456', 'bar']], 200, 200, [{text: "TestButton", action: function(){}}]);
+  var wrapperBlock = new Blockly.Block(blockSpace);
+  wrapperBlock.setFunctional(true);
+  wrapperBlock.initSvg();
+  imgDropdown.sourceBlock_ = wrapperBlock;
+
+  assertEquals(1, imgDropdown.buttons_.length);
+
+  // Generate menu
+  imgDropdown.showMenu_();
+
+  // Check menu has items 'Foo 123', 'Bar 456', and 'TestButton' button
+  let menu = imgDropdown.menu_;
+  assertEquals(3, menu.getItemCount());
+  // Buttons are added at the end of the menu
+  let button = menu.getItemAt(2);
+  assertEquals("TestButton", button.getContent());
+
+  // Elements stay remains in menu after menu is hidden
+  imgDropdown.hideMenu_();
+  assertEquals(3, imgDropdown.menu_.getItemCount());
 }
 
 function test_clampedNumberValidator() {

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -470,6 +470,7 @@ h1 {
       <block type="location_variables_get"></block>
       <block type="location_variables_set"></block>
       <block type="location_variables_set" inline="true"></block>
+      <block type="dropdown_with_button_block" inline="true"></block>
     </category>
     <category name="CSinA Vars" custom="FUNCTIONAL_VARIABLE" />
   </xml>

--- a/tests/playground_requires.js
+++ b/tests/playground_requires.js
@@ -152,6 +152,23 @@ Blockly.Blocks.button_block = {
   },
 };
 
+Blockly.Blocks.dropdown_with_button_block = {
+  // Example block with a dropdown with buttons
+  init: function() {
+    this.setHSV(131, 0.64, 0.62);
+    this.appendDummyInput()
+      .appendTitle("here's a dropdown with buttons")
+      .appendTitle(
+        new Blockly.FieldImageDropdown(
+          [['Foo 123', 'foo'], ['Bar 456', 'bar']],
+          32,
+          32,
+          [{text: "TestButton", action: function(){console.log("Button Clicked")}}]
+        )
+      );
+  },
+};
+
 Blockly.Blocks.ocean_boiler_definition = Object.assign({},
   Blockly.Blocks.procedures_defnoreturn,
   {


### PR DESCRIPTION
Part of Sprite Costumes Feature: https://docs.google.com/document/d/1GBeHLqyTA0nHtD77LgpxIUAvB9xcGfMshb78Ucsn7jw/edit

We want to add a "Draw" and "More" button to the bottom of the costume picker. This PR extends the blockly dropdowns to accept an array of objects that specify the text and eventHandlers of buttons to be added to the bottom of the dropdown.

Example Image:
![Screenshot from 2019-04-05 11-29-59](https://user-images.githubusercontent.com/2959170/55648818-2b057680-5796-11e9-85cb-de5eac93192e.png)


Playground block: (I didn't provide actual links to images, so please ignore the missing link icons and errors)
![blocklywithbuttons](https://user-images.githubusercontent.com/2959170/56672905-18cb7980-666c-11e9-98ff-931d48c07661.gif)
