### PR TITLE
Duplicate block on drag from specified parent block

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -717,10 +717,9 @@ Blockly.Block.prototype.onMouseDown_ = function(e) {
     return;
   } else {
     // Left-click (or middle click)
-    // If this is connected to the parent from which it should duplicate on drag,
-    // duplicate the block, pass the click event to the duplicated block, and
-    // return from this block's click event
-    if(this.copyOnDrag_ && this.getParent() && (this.getParent().type === this.copyOnDrag_)){
+    // If the block should duplicate on drag, duplicate the block, pass the click event
+    // to the duplicated block, and return from this block's click event
+    if(this.shouldCopyOnDrag()){
       let dup = this.duplicate_();
       dup.setParentForCopyOnDrag(null);
       dup.onMouseDown_(e);
@@ -853,7 +852,7 @@ Blockly.Block.prototype.duplicate_ = function() {
   // Move the duplicate next to the old block.
   var xy = this.getRelativeToSurfaceXY();
   // If this is a duplicate on drag, off-set the block by 1 pixel
-  let snapRadius = this.copyOnDrag_ ? 1 : Blockly.SNAP_RADIUS;
+  let snapRadius = this.shoudlCopyOnDrag() ? 1 : Blockly.SNAP_RADIUS;
   if (Blockly.RTL) {
     xy.x -= snapRadius;
   } else {
@@ -1887,10 +1886,11 @@ Blockly.Block.prototype.setParentForCopyOnDrag = function(parent){
 };
 
 /**
- * Returns the type of parent block that indicates this block should duplicate on drag
+ * Returns whether this block is connected to the parent from which it should duplicate on drag
  */
-Blockly.Block.prototype.copyBlockOnDrag = function(){
-  return this.copyOnDrag_;
+Blockly.Block.prototype.shouldCopyOnDrag = function(){
+  let parent = this.getParent();
+  return this.copyOnDrag_ && !!parent && (parent.type === this.copyOnDrag_);
 };
 
 /**

--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -717,6 +717,15 @@ Blockly.Block.prototype.onMouseDown_ = function(e) {
     return;
   } else {
     // Left-click (or middle click)
+    // If this is connected to the parent from which it should duplicate on drag,
+    // duplicate the block, pass the click event to the duplicated block, and
+    // return from this block's click event
+    if(this.copyOnDrag_ && this.getParent() && (this.getParent().type === this.copyOnDrag_)){
+      let dup = this.duplicate_();
+      dup.setParentForCopyOnDrag(null);
+      dup.onMouseDown_(e);
+      return;
+    }
     Blockly.removeAllRanges();
     this.setIsUnused(false);
     this.blockSpace.blockSpaceEditor.setCursor(Blockly.Css.Cursor.CLOSED);
@@ -843,12 +852,14 @@ Blockly.Block.prototype.duplicate_ = function() {
       /** @type {!Blockly.BlockSpace} */ (this.blockSpace), xmlBlock);
   // Move the duplicate next to the old block.
   var xy = this.getRelativeToSurfaceXY();
+  // If this is a duplicate on drag, off-set the block by 1 pixel
+  let snapRadius = this.copyOnDrag_ ? 1 : Blockly.SNAP_RADIUS;
   if (Blockly.RTL) {
-    xy.x -= Blockly.SNAP_RADIUS;
+    xy.x -= snapRadius;
   } else {
-    xy.x += Blockly.SNAP_RADIUS;
+    xy.x += snapRadius;
   }
-  xy.y += Blockly.SNAP_RADIUS * 2;
+  xy.y += snapRadius * 2;
   newBlock.moveBy(xy.x, xy.y);
   return newBlock;
 };
@@ -1864,6 +1875,22 @@ Blockly.Block.prototype.setHSV = function(
     }
     this.render();
   }
+};
+
+/**
+ * Set global variable indicating the parent block that indicates this block should
+ * be duplicated on drag.
+ * @param parent, the parent block indicating this block should duplicate on drag
+ */
+Blockly.Block.prototype.setParentForCopyOnDrag = function(parent){
+  this.copyOnDrag_ = parent;
+};
+
+/**
+ * Returns the type of parent block that indicates this block should duplicate on drag
+ */
+Blockly.Block.prototype.copyBlockOnDrag = function(){
+  return this.copyOnDrag_;
 };
 
 /**

--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -852,7 +852,7 @@ Blockly.Block.prototype.duplicate_ = function() {
   // Move the duplicate next to the old block.
   var xy = this.getRelativeToSurfaceXY();
   // If this is a duplicate on drag, off-set the block by 1 pixel
-  let snapRadius = this.shoudlCopyOnDrag() ? 1 : Blockly.SNAP_RADIUS;
+  let snapRadius = this.shouldCopyOnDrag() ? 1 : Blockly.SNAP_RADIUS;
   if (Blockly.RTL) {
     xy.x -= snapRadius;
   } else {

--- a/tests/blocks_test.js
+++ b/tests/blocks_test.js
@@ -395,3 +395,33 @@ function test_typedParams() {
 
   goog.dom.removeNode(containerDiv);
 }
+
+function test_shouldCopyOnDrag() {
+  let containerDiv = Blockly.Test.initializeBlockSpaceEditor();
+  let blockSpace = Blockly.mainBlockSpace;
+  Blockly.Xml.domToBlockSpace(blockSpace, Blockly.Xml.textToDom(
+    '<xml>' +
+      '<block type="parent">' +
+        '<value name="CLICK">' +
+          '<block type="child">' +
+          '</block>' +
+        '</value>' +
+      '</block>' +
+      '<block type="orphan"></block>' +
+    '</xml>'
+  ));
+  let blocks = blockSpace.getTopBlocks();
+  assertEquals(2, blocks.length);
+
+  let parentBlock = blockSpace.getTopBlocks()[0];
+  let childBlock = parentBlock.getChildren()[0];
+  let orphanBlock = blockSpace.getTopBlocks()[1];
+
+  childBlock.setParentForCopyOnDrag('parent');
+  orphanBlock.setParentForCopyOnDrag('parent');
+
+  assert(childBlock.shouldCopyOnDrag());
+  assertFalse(orphanBlock.shouldCopyOnDrag());
+
+  goog.dom.removeNode(containerDiv);
+}


### PR DESCRIPTION
![semipermanent](https://user-images.githubusercontent.com/2959170/56378390-c993cd80-61c1-11e9-87b0-ab7e27855022.gif)

Part of our prototype for 'mini-toolboxes': https://docs.google.com/document/d/1VV9qHE0qjvas1o8-7zavDpkrbxG9gUmCFRas3Xlwtx4/edit#heading=h.8u7mwfss3758

This changes allows us to indicate a parent block, that when the current block is attached to, the current block will duplicate itself on drag and the duplicated block will continue the drag event (see gif above). 

Example of how it could be called from cdo repo: 
![Screenshot from 2019-04-18 10-09-11](https://user-images.githubusercontent.com/2959170/56378494-0d86d280-61c2-11e9-8c04-7f9890fdb462.png)
