### PR TITLE
Display static and dynamic blocks for behavior blocks

### DIFF
--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -493,7 +493,10 @@ Blockly.Flyout.prototype.show = function(xmlList) {
     );
   } else if (firstBlock === 'Behavior' || Blockly.topLevelProcedureAutopopulate) {
     // Special category for behaviors.
-    if (Blockly.disableProcedureAutopopulate) {
+
+    // For behaviors, allow for a mix of static + dynamic blocks.
+    // Static blocks will appear first in the category
+    if (firstBlock === 'Behavior' || Blockly.disableProcedureAutopopulate) {
       this.layoutXmlToBlocks_(xmlList.slice(1), blocks, gaps, margin);
     }
 


### PR DESCRIPTION
Currently blocking curriculum team

For this task: https://codedotorg.atlassian.net/browse/STAR-289

This change allows for the behavior category in the toolbox to display both static blocks, like "{sprite} begins" and dynamic blocks, like "patrolling".
![Screenshot from 2019-04-19 13-52-33](https://user-images.githubusercontent.com/2959170/56447166-99305a00-62bb-11e9-8b78-4d4e3bc6d44b.png)
