### PR TITLE
Test helpers

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,7 +7,8 @@ module.exports = function(config) {
     files: [
       'node_modules/google-closure-library/closure/goog/base.js',
       'tests/test_dependency_map.js',
-      'tests/*.js',
+      'tests/test_requires_and_utils.js',
+      process.env.FILE || 'tests/*.js',
       'jsunitAdapter.js',
       'msg/js/en_us.js',
       { pattern: 'node_modules/google-closure-library/**/*.js', watched: false, included: false },
@@ -41,4 +42,4 @@ module.exports = function(config) {
       captureConsole: false,
     },
   })
-}
+};

--- a/tests/blocks_test.js
+++ b/tests/blocks_test.js
@@ -423,6 +423,11 @@ function test_shouldCopyOnDrag() {
   assert(childBlock.shouldCopyOnDrag());
   assertFalse(orphanBlock.shouldCopyOnDrag());
 
+  // Should copy when pulled out of the parent block.
+  assertEquals(3, blockSpace.getAllBlocks().length);
+  Blockly.Test.simulateDrag(childBlock, {x: 100, y: 100});
+  assertEquals(4, blockSpace.getAllBlocks().length);
+
   goog.dom.removeNode(containerDiv);
 }
 

--- a/tests/blocks_test.js
+++ b/tests/blocks_test.js
@@ -425,3 +425,23 @@ function test_shouldCopyOnDrag() {
 
   goog.dom.removeNode(containerDiv);
 }
+
+function test_connectTwoBlocks() {
+  let containerDiv = Blockly.Test.initializeBlockSpaceEditor();
+  let blockSpace = Blockly.mainBlockSpace;
+  Blockly.Xml.domToBlockSpace(blockSpace, Blockly.Xml.textToDom(`
+    <xml>
+      <block type="variables_set"></block>
+      <block type="colour_picker"></block>
+    </xml>
+  `));
+
+  const target = blockSpace.getTopBlocks()[0];
+  const orphan = blockSpace.getTopBlocks()[1];
+
+  assertNull(orphan.getParent());
+  Blockly.Test.simulateDrag(orphan, target.getInput('VALUE').connection);
+  assertEquals(target, orphan.getParent());
+
+  goog.dom.removeNode(containerDiv);
+}

--- a/tests/test_requires_and_utils.js
+++ b/tests/test_requires_and_utils.js
@@ -61,3 +61,20 @@ Blockly.Test.testWithReadOnlyBlockSpaceEditor = function (callback) {
   callback(blockSpaceEditor);
   goog.dom.removeNode(container);
 };
+
+/**
+ * Drag the given block to the target destination using mouse events.
+ * @param block {Blockly.Block}
+ * @param destination {Blockly.Connection|Object}
+ */
+Blockly.Test.simulateDrag = function (block, destination = {dx: 100, dy: 100}) {
+  let {dx, dy} = destination;
+  if (destination instanceof Blockly.Connection) {
+    dx = destination.x_ - block.outputConnection.x_;
+    dy = destination.y_ - block.outputConnection.y_;
+  }
+
+  block.getSvgRoot().dispatchEvent(new MouseEvent('mousedown'));
+  document.dispatchEvent(new MouseEvent('mousemove', {clientX: dx, clientY: dy}));
+  document.dispatchEvent(new MouseEvent('mouseup'));
+};


### PR DESCRIPTION
Add `Blockly.Test.simulateDrag` and use it to verify that dragging a should-copy-on-drag block will duplicate it.