### PR TITLE
blocks.js:  modify interpolateMsg 

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -2281,10 +2281,15 @@ Blockly.Block.prototype.interpolateMsg = function(msg, var_args) {
       var tuple = arguments[digit];
       goog.asserts.assertArray(tuple,
           'Message symbol "%s" is out of range.', symbol);
-      this.appendValueInput(tuple[0])
-          .setCheck(tuple[1])
-          .setAlign(tuple[2])
-          .appendTitle(text);
+      if (tuple[0] && typeof tuple[0] === 'function') {
+        this.appendDummyInput().appendTitle(text);
+        tuple[0]();
+      } else {
+        this.appendValueInput(tuple[0])
+            .setCheck(tuple[1])
+            .setAlign(tuple[2])
+            .appendTitle(text);
+      }
       arguments[digit] = null;  // Inputs may not be reused.
     } else if (text) {
       // Trailing dummy input.


### PR DESCRIPTION
The interpolateMsg function is modified to check if the first tuple is a function to render the desired input correctly.   Prior to this update, only value inputs were rendered correctly as any other type of input resulted in an empty socket depicted in the block.

This change is part of the fix to combine variables and strings to give translators more context of the strings and also control how the strings are interpreted.

[jira](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=28&modal=detail&selectedIssue=FND-119&assignee=5c5087d098c1ac41b43286f4)