### PR TITLE
replace all uses of innerHTML assignment that are only intending to deal with text with textContent assignment

### DIFF
--- a/core/ui/contract_editor/contract_editor.js
+++ b/core/ui/contract_editor/contract_editor.js
@@ -182,7 +182,7 @@ Blockly.ContractEditor.prototype.create_ = function() {
   this.hiddenExampleBlocks_ = [];
   this.exampleAreaDiv = goog.dom.createDom('div', 'exampleAreaDiv innerModalDiv');
   this.addExampleButton = goog.dom.createDom('button', 'exampleAreaButton btn');
-  this.addExampleButton.innerHTML = "Add Example";
+  this.addExampleButton.textContent = "Add Example";
   Blockly.bindEvent_(this.addExampleButton, 'click', this, this.addNewExampleBlock_);
   goog.dom.append(this.exampleAreaDiv, this.addExampleButton);
   this.exampleAreaDiv.style.display = 'block';
@@ -190,12 +190,12 @@ Blockly.ContractEditor.prototype.create_ = function() {
   goog.dom.insertChildAt(this.frameClipDiv_, this.exampleAreaDiv, 0);
 
   this.callText = goog.dom.createDom('div', 'callResultText');
-  this.callText.innerHTML = "Call";
+  this.callText.textContent = "Call";
   Blockly.svgIgnoreMouseEvents(this.callText);
   goog.dom.appendChild(this.exampleAreaDiv, this.callText);
 
   this.resultText = goog.dom.createDom('div', 'callResultText');
-  this.resultText.innerHTML = "Result";
+  this.resultText.textContent = "Result";
   goog.dom.appendChild(this.exampleAreaDiv, this.resultText);
   Blockly.svgIgnoreMouseEvents(this.resultText);
 

--- a/core/ui/contract_editor/example_view.js
+++ b/core/ui/contract_editor/example_view.js
@@ -42,7 +42,7 @@ Blockly.ExampleView = function (dom, svg, contractEditor) {
   goog.dom.append(this.domParent_, this.resetExampleButton);
   this.resultText = goog.dom.createDom('div', 'example-result-text');
   Blockly.svgIgnoreMouseEvents(this.resultText);
-  this.resultText.innerHTML = NO_RESULT_TEXT;
+  this.resultText.textContent = NO_RESULT_TEXT;
   goog.dom.append(this.domParent_, this.resultText);
   this.refreshTestingUI(false);
 };
@@ -55,7 +55,7 @@ Blockly.ExampleView.prototype.initializeTestButton_ = function (buttonText,
   var newButton = goog.dom.createDom('button',
     'testButton launch blocklyLaunch exampleAreaButton');
   var testText = goog.dom.createDom('div');
-  testText.innerHTML = buttonText;
+  testText.textContent = buttonText;
   var runImage = goog.dom.createDom('img', iconClass);
   runImage.setAttribute('src', Blockly.assetUrl('media/1x1.gif'));
   goog.dom.append(newButton, runImage);
@@ -92,7 +92,7 @@ Blockly.ExampleView.prototype.reset = function () {
   // old result text
   if (goog.style.isElementShown(this.resetExampleButton)) {
     this.contractEditor_.resetExample(this.block_);
-    this.resultText.innerHTML = NO_RESULT_TEXT;
+    this.resultText.textContent = NO_RESULT_TEXT;
     this.refreshTestingUI(false);
   }
 };
@@ -101,7 +101,7 @@ Blockly.ExampleView.prototype.reset = function () {
  * @param {string} failure The failure text. If null, set to success text
  */
 Blockly.ExampleView.prototype.setResult = function (failure) {
-  this.resultText.innerHTML = failure || SUCCESS_TEXT;
+  this.resultText.textContent = failure || SUCCESS_TEXT;
   this.refreshTestingUI(false);
 };
 

--- a/core/ui/contract_editor/x_button.js
+++ b/core/ui/contract_editor/x_button.js
@@ -23,7 +23,7 @@ Blockly.XButton = function (options) {
 Blockly.XButton.prototype.render = function (parent) {
   var buttonElement = goog.dom.createDom('button');
   buttonElement.className = "btn";
-  buttonElement.innerHTML = "Remove";
+  buttonElement.textContent = "Remove";
   buttonElement.style.marginRight = "-10px"; // specific to contract editor
 
   parent.appendChild(buttonElement);


### PR DESCRIPTION
Most of these uses of innerHTML are harmless, but a couple of them are using innerHTML to insert translated strings. (And arguably, the ones that _aren't_ using translated strings [probably _should_ be](https://codedotorg.atlassian.net/browse/FND-715)).

After this, there are only three instances of `innerHTML` assignment in this project:

```bash
$ git grep innerHTML
core/ui/contract_editor/contract_editor.js:  this.contractDiv_.innerHTML =
core/ui/function_editor.js:  this.container_.querySelector('#paramEditingArea').innerHTML =
core/ui/function_editor.js:  this.contractDiv_.innerHTML =
```

and all of them are actually being used to insert HTML. Followup work will involve making those safe.