### PR TITLE
Add some missing whitespace to the contract editor

### DIFF
--- a/core/ui/contract_editor/contract_editor.js
+++ b/core/ui/contract_editor/contract_editor.js
@@ -545,6 +545,7 @@ Blockly.ContractEditor.prototype.createContractDom_ = function() {
     goog.dom.createDom(goog.dom.TagName.SPAN, {
       id: "domain-label"
     }, Blockly.Msg.FUNCTIONAL_DOMAIN_LABEL),
+    " ",
     goog.dom.createDom(goog.dom.TagName.SPAN, {
       id: "domain-hint",
       "class": "contract-type-hint"


### PR DESCRIPTION
Accidentally removed in https://github.com/code-dot-org/blockly/pull/187/files#diff-07c4a25929b127db8ba45f84c9c05f7cL552