### PR TITLE
Fix AngleHelper for Firefox

### DIFF
--- a/core/ui/fields/angle_helper.js
+++ b/core/ui/fields/angle_helper.js
@@ -52,6 +52,7 @@ Blockly.AngleHelper = function(direction, opt_options) {
   this.arc_ = null;
   this.circle_ = null;
   this.svg_ = null;
+  this.rect_ = null;
   this.variableLine_ = null;
 
   this.animationInterval_ = null;
@@ -112,6 +113,7 @@ Blockly.AngleHelper.prototype.init = function(svgContainer) {
     'width': this.width_ + 'px',
     'style': 'background: rgb(255, 255, 255);',
   }, svgContainer);
+  this.rect_ = this.svg_.getBoundingClientRect();
   this.mouseMoveWrapper_ = Blockly.bindEvent_(this.svg_, 'mousemove', this, this.updateDrag_);
   this.mouseUpWrapper_ = Blockly.bindEvent_(this.svg_, 'mouseup', this, this.stopDrag_);
   this.mouseDownWrapper_ = Blockly.bindEvent_(this.svg_, 'mousedown', this, this.startDrag_);
@@ -216,18 +218,8 @@ Blockly.AngleHelper.prototype.updateDrag_ = function(e) {
     return;
   }
 
-  // try to use offset if we can; touch events don't provide us with an
-  // offset, so calculate it ourselves if we cannot.
-  var x, y;
-  if (e.offsetX && e.offsetY) {
-    x = e.offsetX;
-    y = e.offsetY;
-  } else {
-    var rect = this.svg_.getBoundingClientRect();
-    x = e.clientX - rect.left;
-    y = e.clientY - rect.top;
-  }
-
+  var x = e.clientX - this.rect_.left;
+  var y = e.clientY - this.rect_.top;
   var angle = goog.math.angle(this.center_.x, this.center_.y, x, y);
 
   if (!this.turnRight_) {


### PR DESCRIPTION
`e.offsetX/Y` was giving unpredictable values in Firefox, which was causing the flicker effect. According to https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/offsetX, it's an experimental feature anyways, so switching to always use `e.clientX/Y`, which seems more stable.
Also, moved the bounding rect to an instance variable to avoid repeating the expensive computation unnecessarily since the size of the dropdown does not ever change.

Before
![Feb-04-2020 16-22-45](https://user-images.githubusercontent.com/8787187/73799460-ec9c6780-476a-11ea-8b1a-5573999ac4f9.gif)

After
![Feb-04-2020 16-23-26](https://user-images.githubusercontent.com/8787187/73799468-eefec180-476a-11ea-9a6d-6841008ad23a.gif)

[jira](https://codedotorg.atlassian.net/browse/STAR-650)
