### PR TITLE
Fix block_svg for firefox

### DIFF
--- a/core/ui/block_svg/block_svg.js
+++ b/core/ui/block_svg/block_svg.js
@@ -761,8 +761,14 @@ Blockly.BlockSvg.prototype.updateLimit = function (limit) {
     this.limitText_.textContent = limit;
     Blockly.removeClass_(this.limitGroup_, 'overLimit');
   }
+  var textWidth;
+  try {
+    textWidth = this.limitText_.getBBox ? Math.ceil(this.limitText_.getBBox().width) : HALF_BUBBLE_SIZE;
+  } catch (e) {
+    // Firefox has trouble with hidden elements (Bug 528969).
+    textWidth = HALF_BUBBLE_SIZE;
+  }
 
-  var textWidth = this.limitText_.getBBox ? Math.ceil(this.limitText_.getBBox().width) : HALF_BUBBLE_SIZE;
   var rectWidth = Math.max(textWidth + HALF_BUBBLE_SIZE, BUBBLE_SIZE);
   this.limitRect_.setAttribute('width', rectWidth);
   this.limitText_.setAttribute('x', Math.round(rectWidth * 0.5) - HALF_BUBBLE_SIZE);


### PR DESCRIPTION
`getBBox` does not work with hidden elements in Firefox. https://bugzilla.mozilla.org/show_bug.cgi?id=528969

This is a targeted fix to fix https://studio.code.org/s/coursec-2019/stage/16/puzzle/6, but we should probably look into whether this is causing more widespread issues with Blockly labs on Firefox
