### PR TITLE
[Angle Picker] Adjust min height/width for small dropdowns

### DIFF
--- a/core/ui/fields/field_angle_dropdown.js
+++ b/core/ui/fields/field_angle_dropdown.js
@@ -56,8 +56,8 @@ Blockly.FieldAngleDropdown.prototype.showEditor_ = function() {
 
   var menuDom = this.menu_.getElement();
   var menuSize = goog.style.getSize(menuDom);
-  var angleHelperHeight = menuSize.height;
-  var angleHelperWidth = Math.min(menuSize.height, 150);
+  var angleHelperHeight = Math.max(menuSize.height, 150);
+  var angleHelperWidth = 150;
 
   container.style.height = angleHelperHeight + 'px';
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/8787187/77459116-74424200-6dbc-11ea-8aa2-e9384117f213.png)

After:
![image](https://user-images.githubusercontent.com/8787187/77459137-7d331380-6dbc-11ea-9ac0-74d02ab55b0f.png)

Longer dropdowns are unaffected:
![image](https://user-images.githubusercontent.com/8787187/77459178-8b812f80-6dbc-11ea-886f-b27ad8724a6d.png)
