### PR TITLE
[DO-NOT-MERGE] Add "block id" as Attribute in XML Serialization

### DIFF
--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -155,6 +155,9 @@ Blockly.Xml.blockToDom = function(block, ignoreChildBlocks) {
     element.setAttribute('id', block.htmlId);
   }
 
+  // Add ID as an attribute
+  element.setAttribute('blockid', block.id);
+
   // Don't follow connections if we're ignoring child blocks
   if (block.nextConnection && !ignoreChildBlocks) {
     var nextBlock = block.nextConnection.targetBlock();


### PR DESCRIPTION
Example:

```
<xml><block type="when_run" deletable="false" movable="false" blockid="6"><next><block type="maze_turn" blockid="7"><title name="DIR">turnRight</title><next><block type="maze_nectar" blockid="8"><next><block type="controls_repeat" blockid="9"><title name="TIMES">5</title><statement name="DO"><block type="maze_turn" blockid="10"><title name="DIR">turnLeft</title><next><block type="maze_nectar" blockid="11"></block></next></block></statement></block></next></block></next></block></next></block></xml>
```