### PR TITLE
Fire change event when new value is selected

### DIFF
--- a/core/ui/fields/field_rectangular_dropdown.js
+++ b/core/ui/fields/field_rectangular_dropdown.js
@@ -355,6 +355,10 @@ Blockly.FieldRectangularDropdown.prototype.setValue = function(newValue) {
     this.value_ = newValue;
   }
   this.refreshPreview_();
+
+  if (this.sourceBlock_) {
+    this.sourceBlock_.blockSpace.fireChangeEvent();
+  }
 };
 
 Blockly.FieldRectangularDropdown.prototype.refreshPreview_ = function() {


### PR DESCRIPTION
We should fire a change event when you pick an option from a dropdown so that we update the preview immediately. Currently, we don't update the preview until you click outside the block.

Before:
![Mar-27-2020 15-04-30](https://user-images.githubusercontent.com/8787187/77804290-67338600-703c-11ea-8495-2a9c983a6cbe.gif)
![Mar-27-2020 15-05-12](https://user-images.githubusercontent.com/8787187/77804292-68fd4980-703c-11ea-94e1-6f26fea96c37.gif)


After:
![Mar-27-2020 15-02-01](https://user-images.githubusercontent.com/8787187/77804139-1459ce80-703c-11ea-84a5-701829961cc4.gif)
![Mar-27-2020 15-01-08](https://user-images.githubusercontent.com/8787187/77804142-16239200-703c-11ea-8dfc-93c0c4640e3b.gif)
