### PR TITLE
Catch case where this.picker_ is null

### DIFF
--- a/core/ui/fields/angle_helper.js
+++ b/core/ui/fields/angle_helper.js
@@ -102,7 +102,7 @@ Blockly.AngleHelper.prototype.setAngle = function(angle, skipSnap) {
 };
 
 Blockly.AngleHelper.prototype.getAngle = function() {
-  return this.picker_.angle;
+  return this.picker_ ? this.picker_.angle : 0;
 };
 
 Blockly.AngleHelper.prototype.init = function(svgContainer) {


### PR DESCRIPTION
We started getting a ton of JS errors from somehow trying to call getAngle() when this.picker_ is null [See NewRelic](https://rpm.newrelic.com/accounts/501463/browser/3787364/errors/details#?tw_start=&tw_end=now&tw_offset=259200000&selectedItem=Cannot%20read%20property%20'angle'%20of%20null). We haven't been able to repro the issue ourselves, afaik.
Adding this preventative check in getAngle that handles the null case and defaults to 0 can't really hurt, though, and will silence the new relic noise.