### PR TITLE
Ignore mousedown for multiple touch points

### DIFF
--- a/core/utils/utils.js
+++ b/core/utils/utils.js
@@ -123,14 +123,18 @@ Blockly.bindEvent_ = function(element, name, thisObject, func, useCapture) {
         }
       }
 
-      // Punt on multitouch events.
+      // For mousedown events, only process if one touch point occurs.
+      // This avoids us taking over input when two or more touch points
+      // occur simultaneously, for example allowing the user to do a pinch-zoom.
       var touchPoints = e.changedTouches || [e];
-      for (var i = 0; i < touchPoints.length; ++i) {
-        // Map the touch event's properties to the event.
-        e.clientX = touchPoints[i].clientX;
-        e.clientY = touchPoints[i].clientY;
+      if (name !== "mousedown" || touchPoints.length === 1) {
+        for (var i = 0; i < touchPoints.length; ++i) {
+          // Map the touch event's properties to the event.
+          e.clientX = touchPoints[i].clientX;
+          e.clientY = touchPoints[i].clientY;
 
-        func.apply(thisObject, arguments);
+          func.apply(thisObject, arguments);
+        }
       }
     };
     element.addEventListener(equivTouchEvent, wrapFunc, useCapture);


### PR DESCRIPTION
This is a proposal to only handle `mousedown` (well, really `touchstart`) events when a single touch point is involved.  But I'm not sure whether it's actually a good idea or not, so am using this PR to capture what I've learned in the last day or so.

We have a challenge viewing our level pages on mobile devices, related to zoom.  Especially when switching between portrait and landscape, users can end up zoomed in, and need to zoom back out to see the whole screen.  Unfortunately, the Blockly area "takes over" the ability to zoom and pan on a mobile phone, and so the user has to find somewhere on the page to grab that actually lets the browser do its zoom and pan.

Blockly "takes over" through a `preventDefault` on `mousedown` [here](https://github.com/code-dot-org/blockly/blob/master/core/ui/block_space/pan_drag_handler.js#L206).  Commenting out that line allows the user to use one finger to scroll the whole page, and two fingers to zoom.  However, Blockly does this takeover because has a custom scrolling implementation,  and it allows a mouse drag or touch drag to control the scrolling anywhere on its pane.  The latest Blockly [demo](https://blockly-demo.appspot.com/static/demos/fixed/index.html) also exhibits the same behaviour on a mobile phone.

I had hoped that we might be able to detect any touch with more than one finger, and then pass control back to the browser, but it appears that any `touchstart` that encounters a `preventDefault` will take over control from the browser.  This means that if one finger is placed first, and then a second goes down, the browser has already lost the ability to own the zoom.  (I'd love to be found wrong on this!)

And so all this PR manages to offer is detecting a `touchstart `when two fingers are placed simultaneously.  In this case, Blockly does avoid taking over, and allows the user to then do their zoom.  It's pretty tricky to do this gesture, though, and the added risk is that they could do it once to make their zoom worse, and then not be able to do it again to make it better.

The better long term solution for us it to probably prevent Blockly from doing this takeover, either by
  - always having a pane big enough for the entire program, or
  - implementing a browser-native scrolling surface inside Blockly

The former becomes a factor as we think about the right mobile experience for an entire level page; it might still be useful even if we want to show a pane bigger than a mobile device's physical screen.  The latter still has complications in any future native experience we build, because scrolling components inside a scrolling page have their own difficulties, especially on mobile devices.
