### PR TITLE
Add a background behind flyout button

### DIFF
--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -574,6 +574,12 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   }
   this.width_ = 0;
   this.reflow();
+  // After filling the flyout, if there's a flyout button, we should 
+  // update the width of the background rectange to fill the width of the flyout
+  var flyoutButton = document.getElementsByClassName('createFunction')[0];
+  if (flyoutButton) {
+    flyoutButton.children[0].setAttribute('width', Math.max(0, this.getMetrics_().viewWidth - 15));
+  }
 
   this.filterForCapacity_();
   this.updateBlockLimitTotals_();
@@ -593,28 +599,41 @@ Blockly.Flyout.prototype.show = function(xmlList) {
  * @private
  */
 Blockly.Flyout.prototype.addButtonToFlyout_ = function(cursor, buttonText, onMouseDown) {
-  var button = Blockly.createSvgElement('g', {'class': 'createFunction'},
+  var buttonFlyoutArea = Blockly.createSvgElement('g', {'class': 'createFunction'},
     this.blockSpace_.svgGroup_);
   var padding = 5;
-  var r = Blockly.createSvgElement('rect', {
+  var background = Blockly.createSvgElement('rect', {
+    fill: '#ddd',
+    stroke: 'none',
+    height: 50,
+    x: -17,
+    y: -25
+  }, buttonFlyoutArea);
+  var button = Blockly.createSvgElement('rect', {
     rx: 5,
     ry: 5,
     fill: 'orange',
     stroke: 'white'
-  }, button);
+  }, buttonFlyoutArea);
   var text = Blockly.createSvgElement('text', {
     x: padding,
     y: padding,
     'class': 'blocklyText'
-  }, button);
+  }, buttonFlyoutArea);
   text.textContent = buttonText;
   var bounds = text.getBoundingClientRect();
   this.minFlyoutWidth_ = bounds.width + 2 * padding;
-  r.setAttribute('width', bounds.width + 2 * padding);
-  r.setAttribute('height', bounds.height + 2 * padding);
-  r.setAttribute('y', -bounds.height + padding - 1);
-  button.setAttribute('transform', 'translate(17, 25)');
+  // Set minimum width for background, but will be updated to fit the full width of
+  // the flyout once the blocks fill the flyout
+  background.setAttribute('width', bounds.width + 2 * padding);
+  button.setAttribute('width', bounds.width + 2 * padding);
+  button.setAttribute('height', bounds.height + 2 * padding);
+  button.setAttribute('y', -bounds.height + padding - 1);
+  buttonFlyoutArea.setAttribute('transform', 'translate(17, 25)');
+  // Clicking on the text or the button rectangle but not on
+  // the background rectangle should trigger the mouse handler
   Blockly.bindEvent_(button, 'mousedown', this, onMouseDown);
+  Blockly.bindEvent_(text, 'mousedown', this, onMouseDown);
   cursor.y += 40;
 };
 

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -103,9 +103,10 @@ Blockly.Flyout = function(blockSpaceEditor, opt_static) {
   this.enabled_ = true;
   
   /**
-    * Optional button that could be added to the top of the flyout.
+    * Some flyouts have a button added to the top. If there's a button, this
+    * is an opaque background behind it that should match the width of the flyout.
     */
-  this.flyoutButton_ = null;
+  this.flyoutButtonBackground_ = null;
 };
 
 /**
@@ -192,7 +193,7 @@ Blockly.Flyout.prototype.dispose = function() {
   }
   this.svgBackground_ = null;
   this.targetBlockSpace_ = null;
-  this.flyoutButton_ = null;
+  this.flyoutButtonBackground_ = null;
 };
 
 /**
@@ -635,7 +636,7 @@ Blockly.Flyout.prototype.addButtonToFlyout_ = function(cursor, buttonText, onMou
   Blockly.bindEvent_(button, 'mousedown', this, onMouseDown);
   Blockly.bindEvent_(text, 'mousedown', this, onMouseDown);
   cursor.y += 40;
-  this.flyoutButton_ = flyoutButtonArea;
+  this.flyoutButtonBackground_ = background;
 };
 
 /**
@@ -670,8 +671,8 @@ Blockly.Flyout.prototype.reflow = function() {
         block.flyoutRect_.setAttribute('y', blockXY.y);
       }
     }
-    if (this.flyoutButton_) {
-      this.flyoutButton_.children[0].setAttribute('width', Math.max(0, flyoutWidth - 15));
+    if (this.flyoutButtonBackground_) {
+      this.flyoutButtonBackground_.setAttribute('width', Math.max(0, flyoutWidth - 15));
     }
     // Record the width for .getMetrics_ and .position_.
     this.width_ = flyoutWidth;

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -101,6 +101,11 @@ Blockly.Flyout = function(blockSpaceEditor, opt_static) {
    * If disabled, clicks on blocks in flyout will be ignored.
    */
   this.enabled_ = true;
+  
+  /**
+    * Optional button that could be added to the top of the flyout.
+    */
+  this.flyoutButton_ = null;
 };
 
 /**
@@ -187,6 +192,7 @@ Blockly.Flyout.prototype.dispose = function() {
   }
   this.svgBackground_ = null;
   this.targetBlockSpace_ = null;
+  this.flyoutButton_ = null;
 };
 
 /**
@@ -574,12 +580,6 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   }
   this.width_ = 0;
   this.reflow();
-  // After filling the flyout, if there's a flyout button, we should 
-  // update the width of the background rectange to fill the width of the flyout
-  var flyoutButton = document.getElementsByClassName('createFunction')[0];
-  if (flyoutButton) {
-    flyoutButton.children[0].setAttribute('width', Math.max(0, this.getMetrics_().viewWidth - 15));
-  }
 
   this.filterForCapacity_();
   this.updateBlockLimitTotals_();
@@ -599,7 +599,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
  * @private
  */
 Blockly.Flyout.prototype.addButtonToFlyout_ = function(cursor, buttonText, onMouseDown) {
-  var buttonFlyoutArea = Blockly.createSvgElement('g', {'class': 'createFunction'},
+  var flyoutButtonArea = Blockly.createSvgElement('g', {'class': 'createFunction'},
     this.blockSpace_.svgGroup_);
   var padding = 5;
   var background = Blockly.createSvgElement('rect', {
@@ -608,18 +608,18 @@ Blockly.Flyout.prototype.addButtonToFlyout_ = function(cursor, buttonText, onMou
     height: 50,
     x: -17,
     y: -25
-  }, buttonFlyoutArea);
+  }, flyoutButtonArea);
   var button = Blockly.createSvgElement('rect', {
     rx: 5,
     ry: 5,
     fill: 'orange',
     stroke: 'white'
-  }, buttonFlyoutArea);
+  }, flyoutButtonArea);
   var text = Blockly.createSvgElement('text', {
     x: padding,
     y: padding,
     'class': 'blocklyText'
-  }, buttonFlyoutArea);
+  }, flyoutButtonArea);
   text.textContent = buttonText;
   var bounds = text.getBoundingClientRect();
   this.minFlyoutWidth_ = bounds.width + 2 * padding;
@@ -629,12 +629,13 @@ Blockly.Flyout.prototype.addButtonToFlyout_ = function(cursor, buttonText, onMou
   button.setAttribute('width', bounds.width + 2 * padding);
   button.setAttribute('height', bounds.height + 2 * padding);
   button.setAttribute('y', -bounds.height + padding - 1);
-  buttonFlyoutArea.setAttribute('transform', 'translate(17, 25)');
+  flyoutButtonArea.setAttribute('transform', 'translate(17, 25)');
   // Clicking on the text or the button rectangle but not on
   // the background rectangle should trigger the mouse handler
   Blockly.bindEvent_(button, 'mousedown', this, onMouseDown);
   Blockly.bindEvent_(text, 'mousedown', this, onMouseDown);
   cursor.y += 40;
+  this.flyoutButton_ = flyoutButtonArea;
 };
 
 /**
@@ -668,6 +669,9 @@ Blockly.Flyout.prototype.reflow = function() {
             Blockly.RTL ? blockXY.x - blockHW.width : blockXY.x);
         block.flyoutRect_.setAttribute('y', blockXY.y);
       }
+    }
+    if (this.flyoutButton_) {
+      this.flyoutButton_.children[0].setAttribute('width', Math.max(0, flyoutWidth - 15));
     }
     // Record the width for .getMetrics_ and .position_.
     this.width_ = flyoutWidth;


### PR DESCRIPTION
Currently for toolbox categories with a flyout button, there's an issue where the button overlaps the blocks as you scroll.
To resolve, we want to just add an opaque background behind the flyout button so that the blocks scroll underneath.
Before:
![Apr-28-2020 11-54-43](https://user-images.githubusercontent.com/8787187/80547905-38c40600-896e-11ea-80a5-e6abd7b165c4.gif)

After:
![Apr-28-2020 11-53-23](https://user-images.githubusercontent.com/8787187/80547902-3661ac00-896e-11ea-9a90-fbf6cd69c78a.gif)

