### PR TITLE
Sprite Lab Pointer Blocks Shadowing Functionality

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1559,7 +1559,10 @@ Blockly.Block.prototype.addShadowBlock = function(block){
   if (!this.shadowBlocks_) {
     this.shadowBlocks_= [];
   }
-  this.shadowBlocks_.push(block);
+  // First check to make sure the block isn't already in the list.
+  if (!this.shadowBlocks_.includes(block)) {
+    this.shadowBlocks_.push(block);
+  }
 };
 
 /** Sets the list of blocks to keep in sync with this block

--- a/core/ui/fields/field_rectangular_dropdown.js
+++ b/core/ui/fields/field_rectangular_dropdown.js
@@ -237,8 +237,8 @@ Blockly.FieldRectangularDropdown.prototype.generateMenuItemSelectedHandler_ = fu
           let shadowBlocks = this.sourceBlock_.getShadowBlocks();
           let updatedShadowBlocks = [];
           shadowBlocks.forEach(function (block) {
-            let field = block.inputList[0].titleRow[1];
-            if (block.getRootBlock() === root) {
+            let field = block.inputList[0] && block.inputList[0].titleRow[1];
+            if (field && block.getRootBlock() === root) {
               field.setText(sourceValue);
               updatedShadowBlocks.push(block);
             }

--- a/core/ui/fields/field_rectangular_dropdown.js
+++ b/core/ui/fields/field_rectangular_dropdown.js
@@ -231,16 +231,19 @@ Blockly.FieldRectangularDropdown.prototype.generateMenuItemSelectedHandler_ = fu
       var value = menuItem.getValue();
       if (value !== null && value !== undefined) {
         fieldRectanglularDropdown.setValue(value);
-        // If there are additional field images to update in the root block, update them with this preview data
-        let root = this.sourceBlock_ ? this.sourceBlock_.getRootBlock() : null;
-        let relationBlocks = root ? root.getRelationalUpdateBlocks() : null;
-        if(relationBlocks){
-          let updateValue = this.getPreviewDataForValue_(value);
-          relationBlocks.forEach(function(updateFields){
-            if(!updateFields.isDestroyed_()){
-              updateFields.setText(updateValue);
+        if (this.sourceBlock_) {
+          let sourceValue = this.getPreviewDataForValue_(value);
+          let root = this.sourceBlock_.getRootBlock();
+          let shadowBlocks = this.sourceBlock_.getShadowBlocks();
+          let updatedShadowBlocks = [];
+          shadowBlocks.forEach(function (block) {
+            let field = block.inputList[0].titleRow[1];
+            if (block.getRootBlock() === root) {
+              field.setText(sourceValue);
+              updatedShadowBlocks.push(block);
             }
-          });
+          })
+          this.sourceBlock_.setShadowBlocks(updatedShadowBlocks);
         }
       }
     }


### PR DESCRIPTION
Pairs with https://github.com/code-dot-org/code-dot-org/pull/34975
This shadowing behavior is *not* general purpose, and will only work for the combination of blocks needed for mini toolboxes for events. That is, there is a clicked sprite pointer block that can shadow the sprite dropdown block in a clicked event block, and there are subject/object pointer blocks that can shadow the sprite dropdowns in a touch event block. If we ever need any other shadowing, that will need to be built separately. 

![May-26-2020 15-02-41](https://user-images.githubusercontent.com/8787187/82958370-1d96e700-9f6a-11ea-850e-e41b44b5ec28.gif)
![May-26-2020 15-02-12](https://user-images.githubusercontent.com/8787187/82958393-25ef2200-9f6a-11ea-859f-687e0f388887.gif)
