### PR TITLE
Sprite Lab Pointer Blocks Shadowing Functionality

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1568,10 +1568,6 @@ Blockly.Block.prototype.setParent = function(newParent) {
     this.setShadowBlocks([]);
     var shadowBlocks = getShadowBlocksInStack(oldParent);
     let sourceBlock = this;
-    // We only care about shadow blocks that are shadowing this source block.
-    shadowBlocks = shadowBlocks.filter(function (block) {
-      return block.blockToShadow_(oldParent) === this
-    }, this);
     shadowBlocks.forEach(function (block) {
       block.shadowBlockValue_();
     })

--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1470,7 +1470,7 @@ Blockly.Block.prototype.getChildren = function() {
  * @param {Blockly.Block} topBlock - root of the block stack to traverse
  * @return {!Array.<!Blockly.Block>} Array of shadow blocks
  */
-function getShadowBlocksInStack(topBlock, sourceBlock) {
+function getShadowBlocksInStack(topBlock) {
   var shadowBlocks = [];
   var queue = [topBlock];
   while (queue.length) {


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/blockly/pull/218 because that one didn't correctly handle when the sprite blocks were moved. 
There are 5 cases where we might need to update previews on shadow blocks:

1. A sprite block is added to an event socket
![May-27-2020 17-02-55](https://user-images.githubusercontent.com/8787187/83083812-fa3c6c80-a03b-11ea-9c82-43f8e12e3116.gif)

2. A sprite block is removed from an event socket
![May-27-2020 17-02-31](https://user-images.githubusercontent.com/8787187/83083809-f872a900-a03b-11ea-838b-437edd6996c5.gif)

3. A stack of blocks is added to an event stack
![May-27-2020 17-15-18](https://user-images.githubusercontent.com/8787187/83084428-bf3b3880-a03d-11ea-9ba4-f4ec97ef3422.gif)

4. A stack of blocks is removed from an event stack
![May-27-2020 17-15-43](https://user-images.githubusercontent.com/8787187/83084444-c8c4a080-a03d-11ea-9005-43c5d96afbda.gif)

5. Value in the sprite dropdown changes
![May-27-2020 17-16-58](https://user-images.githubusercontent.com/8787187/83084476-e8f45f80-a03d-11ea-9cf3-dd7300781dde.gif)

The last case is sort of a special case because it doesn't change the block tree at all. In the first four cases, though, the process is basically that we need to find all of the shadow blocks in the stack, and update them with the new thumbnail (or remove the thumbnail). This is done by a straightforward tree traversal (`getShadowBlocksInStack`).

For the 5th case, we maintain a list of shadow blocks for each sprite block. So then when the value changes, all we need to do is go through that list and update the previews:
https://github.com/code-dot-org/blockly/blob/b11192fbc9054e0a6b11f20333d9ea78b08d312a/core/ui/fields/field_rectangular_dropdown.js#L239-L246