### PR TITLE
Allowed the toolbox to display with a truncated width

### DIFF
--- a/core/ui/block_space/block_space.js
+++ b/core/ui/block_space/block_space.js
@@ -323,12 +323,22 @@ Blockly.BlockSpace.prototype.findFunctionExamples = function(functionName) {
   });
 };
 
-Blockly.BlockSpace.prototype.resizeToolbox = function(maxWidth) {
-  if (this.clipRect_ && this.clipRect_.width !== maxWidth) {
-    this.clipRect_.setAttribute('width', maxWidth);
+/**
+ * Sets the visible width of the block space. Specifically, it sets the width of
+ * the clipping rectangle which hides sections of the SVG.
+ * @param {Number} width The width to set for the clipping rectangle.
+ */
+Blockly.BlockSpace.prototype.resizeWidth = function(width) {
+  if (this.clipRect_ && this.clipRect_.width !== width) {
+    this.clipRect_.setAttribute('width', width);
   }
 };
 
+/**
+ * Sets the visible height of the block space. Specifically, it sets the height
+ * of the clipping rectangle to ensure it displays the entire height of the
+ * block space.
+ */
 Blockly.BlockSpace.prototype.resizeHeight = function() {
   var height = this.getMetrics() && this.getMetrics().contentHeight;
   if (height) {
@@ -340,7 +350,7 @@ Blockly.BlockSpace.prototype.resizeHeight = function() {
  * Create the trash can elements.
  * @return {!Element} The blockSpace's SVG group.
  */
-Blockly.BlockSpace.prototype.createDom = function(clipWidth) {
+Blockly.BlockSpace.prototype.createDom = function(shouldClipWidth) {
   /*
   <g>
     [Trashcan may go here]
@@ -351,7 +361,7 @@ Blockly.BlockSpace.prototype.createDom = function(clipWidth) {
   this.svgGroup_ = Blockly.createSvgElement('g', {'class': 'svgGroup'}, null);
   this.clippingGroup_ = Blockly.createSvgElement('g', {'class': 'svgClippingGroup'}, this.svgGroup_);
   let blockCanvasOptions = {'class': 'svgBlockCanvas'};
-  if (clipWidth) {
+  if (shouldClipWidth) {
     this.defs_ = Blockly.createSvgElement('defs', {}, this.clippingGroup_);
     this.clipPath_ = Blockly.createSvgElement('clipPath', {'id': 'clipToolbox'}, this.defs_);
     // At this point, we don't know the width and height. We will set those later.

--- a/core/ui/block_space/block_space.js
+++ b/core/ui/block_space/block_space.js
@@ -325,9 +325,16 @@ Blockly.BlockSpace.prototype.findFunctionExamples = function(functionName) {
 
 Blockly.BlockSpace.prototype.resizeToolbox = function(maxWidth) {
   if (this.clipRect_ && this.clipRect_.width !== maxWidth) {
-    this.clipRect_.setAttribute('width', maxWidth)
+    this.clipRect_.setAttribute('width', maxWidth);
   }
-}
+};
+
+Blockly.BlockSpace.prototype.resizeHeight = function() {
+  var height = this.getMetrics() && this.getMetrics().contentHeight;
+  if (height) {
+    this.clipRect_.setAttribute('height', height);
+  }
+};
 
 /**
  * Create the trash can elements.
@@ -344,13 +351,11 @@ Blockly.BlockSpace.prototype.createDom = function(clipWidth) {
   this.svgGroup_ = Blockly.createSvgElement('g', {'class': 'svgGroup'}, null);
   this.clippingGroup_ = Blockly.createSvgElement('g', {'class': 'svgClippingGroup'}, this.svgGroup_);
   let blockCanvasOptions = {'class': 'svgBlockCanvas'};
-  let height = 800 // clippingGroupHeight
   if (clipWidth) {
-    debugger;
     this.defs_ = Blockly.createSvgElement('defs', {}, this.clippingGroup_);
     this.clipPath_ = Blockly.createSvgElement('clipPath', {'id': 'clipToolbox'}, this.defs_);
     // At this point, we don't know the width and height. We will set those later.
-    this.clipRect_ = Blockly.createSvgElement('rect', {'x': '0', 'y': '0', 'height': height}, this.clipPath_);
+    this.clipRect_ = Blockly.createSvgElement('rect', {'x': '0', 'y': '0'}, this.clipPath_);
     blockCanvasOptions['clip-path'] = 'url(#clipToolbox)';
   }
   this.svgBlockCanvas_ = Blockly.createSvgElement('g', blockCanvasOptions, this.clippingGroup_);

--- a/core/ui/block_space/block_space.js
+++ b/core/ui/block_space/block_space.js
@@ -323,11 +323,17 @@ Blockly.BlockSpace.prototype.findFunctionExamples = function(functionName) {
   });
 };
 
+Blockly.BlockSpace.prototype.resizeToolbox = function(maxWidth) {
+  if (this.clipRect_ && this.clipRect_.width !== maxWidth) {
+    this.clipRect_.setAttribute('width', maxWidth)
+  }
+}
+
 /**
  * Create the trash can elements.
  * @return {!Element} The blockSpace's SVG group.
  */
-Blockly.BlockSpace.prototype.createDom = function() {
+Blockly.BlockSpace.prototype.createDom = function(clipWidth) {
   /*
   <g>
     [Trashcan may go here]
@@ -337,7 +343,17 @@ Blockly.BlockSpace.prototype.createDom = function() {
   */
   this.svgGroup_ = Blockly.createSvgElement('g', {'class': 'svgGroup'}, null);
   this.clippingGroup_ = Blockly.createSvgElement('g', {'class': 'svgClippingGroup'}, this.svgGroup_);
-  this.svgBlockCanvas_ = Blockly.createSvgElement('g', {'class': 'svgBlockCanvas'}, this.clippingGroup_);
+  let blockCanvasOptions = {'class': 'svgBlockCanvas'};
+  let height = 800 // clippingGroupHeight
+  if (clipWidth) {
+    debugger;
+    this.defs_ = Blockly.createSvgElement('defs', {}, this.clippingGroup_);
+    this.clipPath_ = Blockly.createSvgElement('clipPath', {'id': 'clipToolbox'}, this.defs_);
+    // At this point, we don't know the width and height. We will set those later.
+    this.clipRect_ = Blockly.createSvgElement('rect', {'x': '0', 'y': '0', 'height': height}, this.clipPath_);
+    blockCanvasOptions['clip-path'] = 'url(#clipToolbox)';
+  }
+  this.svgBlockCanvas_ = Blockly.createSvgElement('g', blockCanvasOptions, this.clippingGroup_);
   this.svgBubbleCanvas_ = Blockly.createSvgElement('g', {'class': 'svgBubbleCanvas'}, this.svgGroup_);
   this.svgDebugCanvas_ = Blockly.createSvgElement('g', {'class': 'svgDebugCanvas'}, this.svgGroup_);
 

--- a/core/ui/block_space/block_space.js
+++ b/core/ui/block_space/block_space.js
@@ -341,7 +341,7 @@ Blockly.BlockSpace.prototype.resizeWidth = function(width) {
  */
 Blockly.BlockSpace.prototype.resizeHeight = function() {
   var height = this.getMetrics() && this.getMetrics().contentHeight;
-  if (height) {
+  if (height && this.clipRect_) {
     this.clipRect_.setAttribute('height', height);
   }
 };

--- a/core/ui/block_space/block_space_editor.js
+++ b/core/ui/block_space/block_space_editor.js
@@ -357,7 +357,7 @@ Blockly.BlockSpaceEditor.prototype.addFlyout_ = function() {
    */
   this.flyout_ = new Blockly.Flyout(this, true);
   var flyout = this.flyout_;
-  var flyoutSvg = flyout.createDom(false);
+  var flyoutSvg = flyout.createDom(false /*insideToolbox*/, true /*clipWidth*/);
   flyout.init(this.blockSpace, true);
   flyout.autoClose = false;
   // Insert the flyout behind the blockSpace so that blocks appear on top.
@@ -628,6 +628,9 @@ Blockly.BlockSpaceEditor.prototype.svgResize = function() {
   if (svg.cachedWidth_ != svgWidth) {
     svg.setAttribute('width', svgWidth + 'px');
     svg.cachedWidth_ = svgWidth;
+    if (this.flyout_) {
+      this.flyout_.setMaxWidth_(svgWidth/2.5);
+    }
   }
   if (svg.cachedHeight_ != svgHeight) {
     svg.setAttribute('height', svgHeight + 'px');

--- a/core/ui/block_space/block_space_editor.js
+++ b/core/ui/block_space/block_space_editor.js
@@ -357,7 +357,7 @@ Blockly.BlockSpaceEditor.prototype.addFlyout_ = function() {
    */
   this.flyout_ = new Blockly.Flyout(this, true);
   var flyout = this.flyout_;
-  var flyoutSvg = flyout.createDom(false /*insideToolbox*/, true /*shouldClipWidth*/);
+  var flyoutSvg = flyout.createStaticToolboxDom();
   flyout.init(this.blockSpace, true);
   flyout.autoClose = false;
   // Insert the flyout behind the blockSpace so that blocks appear on top.

--- a/core/ui/block_space/block_space_editor.js
+++ b/core/ui/block_space/block_space_editor.js
@@ -357,7 +357,7 @@ Blockly.BlockSpaceEditor.prototype.addFlyout_ = function() {
    */
   this.flyout_ = new Blockly.Flyout(this, true);
   var flyout = this.flyout_;
-  var flyoutSvg = flyout.createDom(false /*insideToolbox*/, true /*clipWidth*/);
+  var flyoutSvg = flyout.createDom(false /*insideToolbox*/, true /*shouldClipWidth*/);
   flyout.init(this.blockSpace, true);
   flyout.autoClose = false;
   // Insert the flyout behind the blockSpace so that blocks appear on top.
@@ -629,7 +629,8 @@ Blockly.BlockSpaceEditor.prototype.svgResize = function() {
     svg.setAttribute('width', svgWidth + 'px');
     svg.cachedWidth_ = svgWidth;
     if (this.flyout_) {
-      this.flyout_.setMaxWidth_(svgWidth/2.5);
+      this.flyout_.setMaxWidth(svgWidth/2.5);
+      this.flyout_.blockSpace_.resizeHeight();
     }
   }
   if (svg.cachedHeight_ != svgHeight) {

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -142,8 +142,19 @@ Blockly.Flyout.prototype.CORNER_RADIUS = 8;
 Blockly.Flyout.prototype.onResizeWrapper_ = null;
 
 /**
+ * Creates the flyout's DOM in the format needed for a non-category toolbox.
+ * Only needs to be called once.
+ * @return {!Element} The flyout's SVG group.
+ */
+Blockly.Flyout.prototype.createStaticToolboxDom = function() {
+  return this.createDom(false /*insideToolbox*/, true /*shouldClipWidth*/);
+};
+
+/**
  * Creates the flyout's DOM.  Only needs to be called once.
  * @type {boolean} insideToolbox Whether this flyout is in a toolbox.
+ * @type {boolean} shouldClipWidth Whether this flyout should clip blocks that
+ *                 go beyond a certain maximum width.
  * @return {!Element} The flyout's SVG group.
  */
 Blockly.Flyout.prototype.createDom = function(insideToolbox, shouldClipWidth) {

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -146,7 +146,7 @@ Blockly.Flyout.prototype.onResizeWrapper_ = null;
  * @type {boolean} insideToolbox Whether this flyout is in a toolbox.
  * @return {!Element} The flyout's SVG group.
  */
-Blockly.Flyout.prototype.createDom = function(insideToolbox, clipWidth) {
+Blockly.Flyout.prototype.createDom = function(insideToolbox, shouldClipWidth) {
   /*
   <g>
     <path class="blocklyFlyoutBackground"/>
@@ -156,7 +156,7 @@ Blockly.Flyout.prototype.createDom = function(insideToolbox, clipWidth) {
   this.svgGroup_ = Blockly.createSvgElement('g', {'class': 'svgFlyoutGroup'}, null);
   this.svgBackground_ = Blockly.createSvgElement('path',
       {'class': 'blocklyFlyoutBackground'}, this.svgGroup_);
-  this.svgGroup_.appendChild(this.blockSpace_.createDom(clipWidth));
+  this.svgGroup_.appendChild(this.blockSpace_.createDom(shouldClipWidth));
 
   // Add a trashcan.
   if (!insideToolbox) {
@@ -593,10 +593,14 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   this.blockSpace_.fireChangeEvent();
 };
 
-Blockly.Flyout.prototype.setMaxWidth_ = function(maxWidth) {
+/**
+ * Limits the sets the maximum width of the flyout and re-renders the flyout
+ * @param {Number} maxWidth The maximum allowed width of the flyout.
+ */
+Blockly.Flyout.prototype.setMaxWidth = function(maxWidth) {
   this.maxWidth_ = maxWidth;
   this.reflow();
-  this.blockSpace_.resizeToolbox(maxWidth);
+  this.blockSpace_.resizeWidth(maxWidth);
 };
 
 /**
@@ -688,8 +692,6 @@ Blockly.Flyout.prototype.reflow = function() {
     }
     // Record the width for .getMetrics_ and .position_.
     this.width_ = flyoutWidth;
-    // Fire a resize event to update the flyout's scrollbar.
-    // Blockly.fireUiEvent(window, 'resize');
   }
 };
 

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -581,6 +581,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   }
   this.width_ = 0;
   this.reflow();
+  this.blockSpace_.resizeHeight();
 
   this.filterForCapacity_();
   this.updateBlockLimitTotals_();
@@ -661,7 +662,9 @@ Blockly.Flyout.prototype.reflow = function() {
                  Blockly.Scrollbar.scrollbarThickness;
 
   // set the max width based on the size of the available space for the workspace
-  flyoutWidth = this.maxWidth_ ? Math.min(flyoutWidth, this.maxWidth_) : flyoutWidth;
+  if (this.maxWidth_) {
+    flyoutWidth = Math.min(flyoutWidth, this.maxWidth_);
+  }
   if (this.width_ != flyoutWidth) {
     for (var x = 0, block; block = blocks[x]; x++) {
       var blockHW = block.getHeightWidth();

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -101,7 +101,7 @@ Blockly.Flyout = function(blockSpaceEditor, opt_static) {
    * If disabled, clicks on blocks in flyout will be ignored.
    */
   this.enabled_ = true;
-  
+
   /**
     * Some flyouts have a button added to the top. If there's a button, this
     * is an opaque background behind it that should match the width of the flyout.
@@ -146,7 +146,7 @@ Blockly.Flyout.prototype.onResizeWrapper_ = null;
  * @type {boolean} insideToolbox Whether this flyout is in a toolbox.
  * @return {!Element} The flyout's SVG group.
  */
-Blockly.Flyout.prototype.createDom = function(insideToolbox) {
+Blockly.Flyout.prototype.createDom = function(insideToolbox, clipWidth) {
   /*
   <g>
     <path class="blocklyFlyoutBackground"/>
@@ -156,7 +156,7 @@ Blockly.Flyout.prototype.createDom = function(insideToolbox) {
   this.svgGroup_ = Blockly.createSvgElement('g', {'class': 'svgFlyoutGroup'}, null);
   this.svgBackground_ = Blockly.createSvgElement('path',
       {'class': 'blocklyFlyoutBackground'}, this.svgGroup_);
-  this.svgGroup_.appendChild(this.blockSpace_.createDom());
+  this.svgGroup_.appendChild(this.blockSpace_.createDom(clipWidth));
 
   // Add a trashcan.
   if (!insideToolbox) {
@@ -346,7 +346,7 @@ Blockly.Flyout.prototype.position_ = function() {
 
   // Center the trashcan
   if (this.svgTrashcan_) {
-    var flyoutWidth = this.svgGroup_.getBoundingClientRect().width;
+    var flyoutWidth = this.width_;
     var trashcanWidth = 70;
     var trashcanX = Math.round(flyoutWidth / 2 - trashcanWidth / 2);
     this.svgTrashcan_.setAttribute('transform', 'translate(' + trashcanX + ', 20)');
@@ -592,6 +592,12 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   this.blockSpace_.fireChangeEvent();
 };
 
+Blockly.Flyout.prototype.setMaxWidth_ = function(maxWidth) {
+  this.maxWidth_ = maxWidth;
+  this.reflow();
+  this.blockSpace_.resizeToolbox(maxWidth);
+};
+
 /**
  * Adds a rectangular SVG button to this flyout's blockSpace
  * @param {{x: Number, y: Number}} cursor current drawing position in flyout
@@ -653,6 +659,9 @@ Blockly.Flyout.prototype.reflow = function() {
   }
   flyoutWidth += margin + Blockly.BlockSvg.TAB_WIDTH + margin / 2 +
                  Blockly.Scrollbar.scrollbarThickness;
+
+  // set the max width based on the size of the available space for the workspace
+  flyoutWidth = this.maxWidth_ ? Math.min(flyoutWidth, this.maxWidth_) : flyoutWidth;
   if (this.width_ != flyoutWidth) {
     for (var x = 0, block; block = blocks[x]; x++) {
       var blockHW = block.getHeightWidth();
@@ -677,7 +686,7 @@ Blockly.Flyout.prototype.reflow = function() {
     // Record the width for .getMetrics_ and .position_.
     this.width_ = flyoutWidth;
     // Fire a resize event to update the flyout's scrollbar.
-    Blockly.fireUiEvent(window, 'resize');
+    // Blockly.fireUiEvent(window, 'resize');
   }
 };
 

--- a/tests/playground_requires.js
+++ b/tests/playground_requires.js
@@ -171,7 +171,7 @@ Blockly.Blocks.button_block = {
     span.style.fill = 'blue';
     span.textContent = 'button';
     this.appendDummyInput()
-        .appendTitle("here's a button")
+        .appendTitle("here's a button on a really long block")
         .appendTitle(
           new Blockly.FieldButton(span, function () {
               return new Promise(resolve => resolve(prompt()));


### PR DESCRIPTION
Prior to this change, the toolbox would expand to fully display all blocks. On small screens, long blocks would cause the toolbox to take up a disproportionate amount of space on the screen. In extreme cases, the toolbox would take up the entire screen and leave no space for the workspace. If we have toolbox categories, this isn't an issue because the toolbox is an overlay that can be dismissed. Without categories, however, this can cause certain labs to become unusable. We address this here by creating a clipping rectangle to define the maximum toolbox space.

- [Task](https://codedotorg.atlassian.net/browse/STAR-1104)
- [Bug](https://codedotorg.atlassian.net/browse/STAR-673)

Example where translation caused the toolbox to take up the entire screen:
https://studio.code.org/s/course2/stage/17/puzzle/11 in Norsk (Bokmål)

Before:
![image](https://user-images.githubusercontent.com/8324574/83203251-e48f7b80-a0fd-11ea-851e-d5c34a186f92.png)

After:
![image](https://user-images.githubusercontent.com/8324574/83203707-ee65ae80-a0fe-11ea-8100-c5ccf8074b97.png)

Example where small screen sizes caused the toolbox to take up most of the screen
https://studio.code.org/s/dance-2019/stage/1/puzzle/4

Before:
![Screenshot_20200528-161602_Chrome](https://user-images.githubusercontent.com/8324574/83204590-0b02e600-a101-11ea-9acd-1792ea240f28.jpg)

After:
![Screenshot_20200528-161516_Chrome](https://user-images.githubusercontent.com/8324574/83204587-09392280-a101-11ea-8b28-56217b8ae151.jpg)

Live Resizing:
![ToolboxResize2](https://user-images.githubusercontent.com/8324574/83204783-85cc0100-a101-11ea-98fe-6e908d8dfd64.gif)