### PR TITLE
Only rerender blockspace when shadow blocks change

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1524,10 +1524,6 @@ Blockly.Block.prototype.setParent = function(newParent) {
   if (newParent) {
     // Add this block to the new parent's child list.
     newParent.childBlocks_.push(this);
-    // If the new block has relational blocks to update, re-render the blocks
-    if (newParent.getShadowBlocks()) {
-      this.blockSpace.render();
-    }
 
     // Account for the transform added by the relative position of the parent.
     var oldXY = this.getRelativeToSurfaceXY();
@@ -1544,8 +1540,10 @@ Blockly.Block.prototype.setParent = function(newParent) {
   } else {
     this.blockSpace.addTopBlock(this);
   }
+  var shouldRerender = false;
   if (newParent && newParent.miniFlyout && this.type === 'gamelab_allSpritesWithAnimation') {
     // Add a sprite block to an event socket
+    shouldRerender = true;
     var shadowBlocks = getShadowBlocksInStack(newParent);
     // We only care about shadow blocks that are shadowing this source block.
     shadowBlocks = shadowBlocks.filter(function (block) {
@@ -1557,6 +1555,7 @@ Blockly.Block.prototype.setParent = function(newParent) {
     })
   } else if (newParent && newParent.getRootBlock().miniFlyout) {
     // Add a block stack to an event stack
+    shouldRerender = true;
     var shadowBlocks = getShadowBlocksInStack(this);
     shadowBlocks.forEach(function (block) {
       block.shadowBlockValue_();
@@ -1564,6 +1563,7 @@ Blockly.Block.prototype.setParent = function(newParent) {
   }
   if (oldParent && oldParent.miniFlyout && this.type === 'gamelab_allSpritesWithAnimation') {
     // Remove a sprite block from an event socket
+    shouldRerender = true;
     this.setShadowBlocks([]);
     var shadowBlocks = getShadowBlocksInStack(oldParent);
     shadowBlocks.forEach(function (block) {
@@ -1571,10 +1571,14 @@ Blockly.Block.prototype.setParent = function(newParent) {
     })
   } else if (oldParent && oldParent.getRootBlock().miniFlyout) {
     // Remove a block stack from an event stack
+    shouldRerender = true;
     var shadowBlocks = getShadowBlocksInStack(this);
     shadowBlocks.forEach(function (block) {
       block.shadowBlockValue_();
     })
+  }
+  if (shouldRerender) {
+    this.blockSpace.render();
   }
 };
 


### PR DESCRIPTION
This fixes the issue that caused this [revert](https://github.com/code-dot-org/code-dot-org/pull/35103), see also this [slack thread](https://codedotorg.slack.com/archives/C1B3PNDL7/p1591129863387900).
Basically the issue was that `newParent.getShadowBlocks()` is always true (`[]` is truthy), so we were rerendering the blockspace (which triggers a resize event) every time `setParent` was called. Updated to only call `this.blockSpace.render()` when blocks are added or removed from a parent with a mini flyout.

Before (Over 13000 resize events!):
![image](https://user-images.githubusercontent.com/8787187/83680354-b692b700-a595-11ea-930e-e62031acc418.png)
After (204 resizes) (this is still a lot, but that's known/unrelated tech debt):
![image](https://user-images.githubusercontent.com/8787187/83680538-f35eae00-a595-11ea-94d1-0ca8077c0ff9.png)
