### PR TITLE
[Mini Toolbox] Dynamically update pointer blocks

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1543,7 +1543,6 @@ Blockly.Block.prototype.setParent = function(newParent) {
   var shouldRerender = false;
   if (newParent && newParent.miniFlyout && this.type === 'gamelab_allSpritesWithAnimation') {
     // Add a sprite block to an event socket
-    shouldRerender = true;
     var shadowBlocks = getShadowBlocksInStack(newParent);
     // We only care about shadow blocks that are shadowing this source block.
     shadowBlocks = shadowBlocks.filter(function (block) {
@@ -1553,9 +1552,9 @@ Blockly.Block.prototype.setParent = function(newParent) {
     shadowBlocks.forEach(function (block) {
       block.shadowBlockValue_();
     })
+    this.blockSpace.render();
   } else if (newParent && newParent.getRootBlock().miniFlyout) {
     // Add a block stack to an event stack
-    shouldRerender = true;
     var shadowBlocks = getShadowBlocksInStack(this);
     shadowBlocks.forEach(function (block) {
       block.shadowBlockValue_();
@@ -1563,7 +1562,6 @@ Blockly.Block.prototype.setParent = function(newParent) {
   }
   if (oldParent && oldParent.miniFlyout && this.type === 'gamelab_allSpritesWithAnimation') {
     // Remove a sprite block from an event socket
-    shouldRerender = true;
     this.setShadowBlocks([]);
     var shadowBlocks = getShadowBlocksInStack(oldParent);
     shadowBlocks.forEach(function (block) {
@@ -1571,14 +1569,10 @@ Blockly.Block.prototype.setParent = function(newParent) {
     })
   } else if (oldParent && oldParent.getRootBlock().miniFlyout) {
     // Remove a block stack from an event stack
-    shouldRerender = true;
     var shadowBlocks = getShadowBlocksInStack(this);
     shadowBlocks.forEach(function (block) {
       block.shadowBlockValue_();
     })
-  }
-  if (shouldRerender) {
-    this.blockSpace.render();
   }
 };
 

--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1540,7 +1540,6 @@ Blockly.Block.prototype.setParent = function(newParent) {
   } else {
     this.blockSpace.addTopBlock(this);
   }
-  var shouldRerender = false;
   if (newParent && newParent.miniFlyout && this.type === 'gamelab_allSpritesWithAnimation') {
     // Add a sprite block to an event socket
     var shadowBlocks = getShadowBlocksInStack(newParent);
@@ -1590,15 +1589,21 @@ Blockly.Block.prototype.shadowBlockValue_ = function() {
       let sourceField = sourceBlock.inputList[0].titleRow[0];
       
       // Only works with clicked/subject/object pointer blocks
-      let fieldToUpdate = this.inputList[0].titleRow[1];
+      let previewField = this.inputList[0].titleRow[1];
+      let textField = this.inputList[0].titleRow[0]
       
-      fieldToUpdate.setText(sourceField.previewElement_.getAttribute("xlink:href"));
+      previewField.setText(sourceField.previewElement_.getAttribute("xlink:href"));
+      previewField.updateDimensions_(32, 32);
+      textField.setText(this.shortString);
       
       // Add this block to the list of blocks to update when the sprite dropdown field is changed.
       sourceBlock.addShadowBlock(this);
     } else {
-      let fieldToUpdate = this.inputList[0].titleRow[1];
-      fieldToUpdate.setText("");
+      let previewField = this.inputList[0].titleRow[1];
+      let textField = this.inputList[0].titleRow[0]
+      previewField.setText("");
+      previewField.updateDimensions_(1, 1);
+      textField.setText(this.longString);
     }
   }
 };
@@ -2680,9 +2685,11 @@ Blockly.Block.prototype.render = function(selfOnly) {
   if (!this.svg_) {
     throw 'Uninitialized block cannot be rendered.  Call block.initSvg()';
   }
-  this.svg_.render(selfOnly);
-  if (this.miniFlyout) {
-    this.miniFlyout.position_();
+  if (this.blockSpace) {
+    this.svg_.render(selfOnly);
+    if (this.miniFlyout) {
+      this.miniFlyout.position_();
+    }
   }
 };
 


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/35215 implements the corresponding cdo changes.

When there's no sprite block to shadow, change the block text to "clicked/subject/object sprite" so it doesn't look weird.
Also contains a quick bug fix with the rerendering logic- we only need to rerender when a new block is added to an event stack, not all four cases.

![Jun-08-2020 15-31-14](https://user-images.githubusercontent.com/8787187/84086682-46bd6b80-a99d-11ea-948b-2333d8e0eee6.gif)
![Jun-08-2020 15-30-09](https://user-images.githubusercontent.com/8787187/84086698-51780080-a99d-11ea-9fe3-ef3de5e8f3c4.gif)
