### PR TITLE
Re-added resize event to update the scrollbar in farmer levels

### DIFF
--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -703,7 +703,9 @@ Blockly.Flyout.prototype.reflow = function() {
     }
     // Record the width for .getMetrics_ and .position_.
     this.width_ = flyoutWidth;
-    // Fire a resize event to update the flyout's scrollbar.
+    // Fire a resize event to update the flyout's scrollbar in case an image was
+    // added to a block after the toolbox finished rendering (common in farmer
+    // pre-reader levels).
     Blockly.fireUiEvent(window, 'resize');
   }
 };


### PR DESCRIPTION
A resize event trigger was removed as part of a feature that allows the width of the toolbox to resize dynamically. It was removed to clean up some resize triggers, but was still needed to correctly size the toolbox if an image was added to a block after the toolbox loaded. This is only needed if the scrollbar is visible.

PR Where this was removed: https://github.com/code-dot-org/blockly/pull/220

Example level: https://studio.code.org/s/allthethings/stage/21/puzzle/3

OLD
![image](https://user-images.githubusercontent.com/8324574/84302707-9a00fc80-ab0a-11ea-9846-3d75e1a6e29a.png)

NEW
![image](https://user-images.githubusercontent.com/8324574/84302735-a5ecbe80-ab0a-11ea-904d-4b1fca4771f4.png)
