### PR TITLE
Don't update sprite pointer thumbnail until the drag has ended

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -834,6 +834,10 @@ Blockly.Block.prototype.onMouseUp_ = function(e) {
 
   if (Blockly.selected) {
     Blockly.selected.setIsUnused();
+    var shadowBlocks = getShadowBlocksInStack(Blockly.selected);
+    shadowBlocks.forEach(function (block) {
+      block.shadowBlockValue_();
+    })
   }
 
   if (Blockly.highlightedConnection_) {
@@ -1583,6 +1587,9 @@ Blockly.Block.prototype.setParent = function(newParent) {
 Blockly.Block.prototype.shadowBlockValue_ = function() {
   if(this.blockToShadow_){
     let root = this.getRootBlock();
+    if (root.isCurrentlyBeingDragged()) {
+      return;
+    }
     let sourceBlock = this.blockToShadow_(root);
     if (sourceBlock && sourceBlock.type === "gamelab_allSpritesWithAnimation") {
       // Only works with allSpritesWithAnimation blocks
@@ -1602,7 +1609,7 @@ Blockly.Block.prototype.shadowBlockValue_ = function() {
       let previewField = this.inputList[0].titleRow[1];
       let textField = this.inputList[0].titleRow[0]
       previewField.setText("");
-      previewField.updateDimensions_(1, 1);
+      previewField.updateDimensions_(1, 32);
       textField.setText(this.longString);
     }
   }


### PR DESCRIPTION
We want to only update the preview once the block has been dropped, not while it's being dragged.
From Mike Harvey: "in most cases, i think students will be keeping the blocks under the same event but may be changing the sequence. if every change triggers a change back and forth, i’m worried it will feel like more is changing than actually is. it’d be impossible to leave a block in a being-dragged state, so it would still have to resolve one way or another depending on where the student put it."

I also have a small change to make the block stay the same height whether or not there's a thumbnail, along the same lines, to make it not seem like it's changing more than it is.

Before:
![Jun-10-2020 14-06-40](https://user-images.githubusercontent.com/8787187/84318690-af365500-ab23-11ea-8e2e-ffa96b2157a7.gif)

After:
![Jun-10-2020 14-05-51](https://user-images.githubusercontent.com/8787187/84318698-b198af00-ab23-11ea-9c44-8a45e12abf59.gif)
