### PR TITLE
[MiniToolbox] Add thumbnails to blocks in the flyout

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1548,7 +1548,7 @@ Blockly.Block.prototype.setParent = function(newParent) {
   if (newParent && newParent.miniFlyout && this.type === 'gamelab_allSpritesWithAnimation') {
     // Add a sprite block to an event socket
     let miniToolboxBlocks = newParent.miniFlyout.blockSpace_.topBlocks_;
-    let rootInputBlocks = newParent.getConnections_().filter(function(connection) {
+    let rootInputBlocks = newParent.getConnections_(true /* all */).filter(function(connection) {
       return connection.type === Blockly.INPUT_VALUE
     }).map(function(connection) {
       return connection.targetBlock()
@@ -1579,7 +1579,7 @@ Blockly.Block.prototype.setParent = function(newParent) {
   if (oldParent && oldParent.miniFlyout && this.type === 'gamelab_allSpritesWithAnimation') {
     // Remove a sprite block from an event socket
     let miniToolboxBlocks = oldParent.miniFlyout.blockSpace_.topBlocks_;
-    let rootInputBlocks = oldParent.getConnections_().filter(function(connection) {
+    let rootInputBlocks = oldParent.getConnections_(true /* all */).filter(function(connection) {
       return connection.type === Blockly.INPUT_VALUE
     }).map(function(connection) {
       return connection.targetBlock()

--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -836,7 +836,8 @@ Blockly.Block.prototype.onMouseUp_ = function(e) {
     Blockly.selected.setIsUnused();
     var shadowBlocks = getShadowBlocksInStack(Blockly.selected);
     shadowBlocks.forEach(function (block) {
-      block.shadowBlockValue_();
+      let sourceBlock = block.blockToShadow_(block.getRootBlock());
+      block.shadowBlockValue_(sourceBlock);
     })
   }
 
@@ -1553,14 +1554,16 @@ Blockly.Block.prototype.setParent = function(newParent) {
     }, this);
     this.setShadowBlocks(shadowBlocks);
     shadowBlocks.forEach(function (block) {
-      block.shadowBlockValue_();
+      let sourceBlock = block.blockToShadow_(block.getRootBlock());
+      block.shadowBlockValue_(sourceBlock);
     })
     this.blockSpace.render();
   } else if (newParent && newParent.getRootBlock().miniFlyout) {
     // Add a block stack to an event stack
     var shadowBlocks = getShadowBlocksInStack(this);
     shadowBlocks.forEach(function (block) {
-      block.shadowBlockValue_();
+      let sourceBlock = block.blockToShadow_(block.getRootBlock());
+      block.shadowBlockValue_(sourceBlock);
     })
   }
   if (oldParent && oldParent.miniFlyout && this.type === 'gamelab_allSpritesWithAnimation') {
@@ -1568,29 +1571,32 @@ Blockly.Block.prototype.setParent = function(newParent) {
     this.setShadowBlocks([]);
     var shadowBlocks = getShadowBlocksInStack(oldParent);
     shadowBlocks.forEach(function (block) {
-      block.shadowBlockValue_();
+      let sourceBlock = block.blockToShadow_(block.getRootBlock());
+      block.shadowBlockValue_(sourceBlock);
     })
   } else if (oldParent && oldParent.getRootBlock().miniFlyout) {
     // Remove a block stack from an event stack
     var shadowBlocks = getShadowBlocksInStack(this);
     shadowBlocks.forEach(function (block) {
-      block.shadowBlockValue_();
+      let sourceBlock = block.blockToShadow_(block.getRootBlock());
+      block.shadowBlockValue_(sourceBlock);
     })
   }
 };
 
 /**
- * Sets the value of this block to the value of the root child field specified.
- * Adds a reference to this block in the root block to track when the value should be updated.
+ * Sets the value of this block to the value of the source block specified.
+ * Adds a reference to this block in the source block so the value can be updated when the
+ * source block's value changes
  * @private
+ * @param {Blockly.Block} sourceBlock - the block whose value to shadow
  */
-Blockly.Block.prototype.shadowBlockValue_ = function() {
+Blockly.Block.prototype.shadowBlockValue_ = function(sourceBlock) {
   if(this.blockToShadow_){
     let root = this.getRootBlock();
     if (root.isCurrentlyBeingDragged()) {
       return;
     }
-    let sourceBlock = this.blockToShadow_(root);
     if (sourceBlock && sourceBlock.type === "gamelab_allSpritesWithAnimation") {
       // Only works with allSpritesWithAnimation blocks
       let sourceField = sourceBlock.inputList[0].titleRow[0];

--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1600,7 +1600,7 @@ Blockly.Block.prototype.shadowBlockValue_ = function() {
       let textField = this.inputList[0].titleRow[0]
       
       previewField.setText(sourceField.previewElement_.getAttribute("xlink:href"));
-      previewField.updateDimensions_(32, 32);
+      previewField.updateDimensions_(this.thumbnailSize, this.thumbnailSize);
       textField.setText(this.shortString);
       
       // Add this block to the list of blocks to update when the sprite dropdown field is changed.
@@ -1609,7 +1609,7 @@ Blockly.Block.prototype.shadowBlockValue_ = function() {
       let previewField = this.inputList[0].titleRow[1];
       let textField = this.inputList[0].titleRow[0]
       previewField.setText("");
-      previewField.updateDimensions_(1, 32);
+      previewField.updateDimensions_(1, this.thumbnailSize);
       textField.setText(this.longString);
     }
   }

--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1547,6 +1547,16 @@ Blockly.Block.prototype.setParent = function(newParent) {
   }
   if (newParent && newParent.miniFlyout && this.type === 'gamelab_allSpritesWithAnimation') {
     // Add a sprite block to an event socket
+    let miniToolboxBlocks = newParent.miniFlyout.blockSpace_.topBlocks_;
+    let rootInputBlocks = newParent.getConnections_().filter(function(connection) {
+      return connection.type === Blockly.INPUT_VALUE
+    }).map(function(connection) {
+      return connection.targetBlock()
+    });
+    miniToolboxBlocks.forEach(function(block, index) {
+      block.shadowBlockValue_(rootInputBlocks[index]);
+    });
+
     var shadowBlocks = getShadowBlocksInStack(newParent);
     // We only care about shadow blocks that are shadowing this source block.
     shadowBlocks = shadowBlocks.filter(function (block) {
@@ -1568,6 +1578,16 @@ Blockly.Block.prototype.setParent = function(newParent) {
   }
   if (oldParent && oldParent.miniFlyout && this.type === 'gamelab_allSpritesWithAnimation') {
     // Remove a sprite block from an event socket
+    let miniToolboxBlocks = oldParent.miniFlyout.blockSpace_.topBlocks_;
+    let rootInputBlocks = oldParent.getConnections_().filter(function(connection) {
+      return connection.type === Blockly.INPUT_VALUE
+    }).map(function(connection) {
+      return connection.targetBlock()
+    });
+    miniToolboxBlocks.forEach(function(block, index) {
+      block.shadowBlockValue_(rootInputBlocks[index]);
+    });
+    
     this.setShadowBlocks([]);
     var shadowBlocks = getShadowBlocksInStack(oldParent);
     shadowBlocks.forEach(function (block) {

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -833,6 +833,21 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
     var xyNew = Blockly.getSvgXY_(svgRootNew,
         block.blockSpace.blockSpaceEditor.svg_);
     block.moveBy(xyOld.x - xyNew.x, xyOld.y - xyNew.y);
+    
+    if (block.blockToShadow_) {
+      let src = "";
+      if (originBlock.inputList[0] && originBlock.inputList[0].titleRow[1]) {
+        src = originBlock.inputList[0].titleRow[1].src_;
+      }
+      if (src != "") {
+        block.inputList[0].titleRow[1].setText(originBlock.inputList[0].titleRow[1].src_);  
+        block.inputList[0].titleRow[1].updateDimensions_(block.thumbnailSize, block.thumbnailSize);
+      } else {
+        block.inputList[0].titleRow[0].setText(block.longString);
+        block.inputList[0].titleRow[1].updateDimensions_(1, block.thumbnailSize);
+      }
+    }
+    
     if (flyout.autoClose) {
       /**
        * We need to avoid destroying the currently dragged block

--- a/core/ui/fields/field_rectangular_dropdown.js
+++ b/core/ui/fields/field_rectangular_dropdown.js
@@ -234,16 +234,29 @@ Blockly.FieldRectangularDropdown.prototype.generateMenuItemSelectedHandler_ = fu
         if (this.sourceBlock_) {
           let sourceValue = this.getPreviewDataForValue_(value);
           let root = this.sourceBlock_.getRootBlock();
-          let shadowBlocks = this.sourceBlock_.getShadowBlocks();
-          let updatedShadowBlocks = [];
-          shadowBlocks.forEach(function (block) {
-            let field = block.inputList[0] && block.inputList[0].titleRow[1];
-            if (field && block.getRootBlock() === root) {
+          if (root.miniFlyout) {
+            let miniToolboxBlocks = root.miniFlyout.blockSpace_.topBlocks_;
+            let socketIndex = root.getConnections_().filter(function(connection) {
+              return connection.type === Blockly.INPUT_VALUE
+            }).map(function(connection) {
+              return connection.targetBlock()
+            }).indexOf(this.sourceBlock_);
+            if (socketIndex !== -1) {
+              let field = miniToolboxBlocks[socketIndex].inputList[0].titleRow[1];
               field.setText(sourceValue);
-              updatedShadowBlocks.push(block);
             }
-          })
-          this.sourceBlock_.setShadowBlocks(updatedShadowBlocks);
+            
+            let shadowBlocks = this.sourceBlock_.getShadowBlocks();
+            let updatedShadowBlocks = [];
+            shadowBlocks.forEach(function (block) {
+              let field = block.inputList[0] && block.inputList[0].titleRow[1];
+              if (field && block.getRootBlock() === root) {
+                field.setText(sourceValue);
+                updatedShadowBlocks.push(block);
+              }
+            })
+            this.sourceBlock_.setShadowBlocks(updatedShadowBlocks);  
+          }
         }
       }
     }


### PR DESCRIPTION
This sets up the blocks in the mini toolbox flyout to have the right sprite thumbnail.
![Jun-16-2020 14-40-42](https://user-images.githubusercontent.com/8787187/84831149-ab9d4500-afdf-11ea-9923-f4c143e7ced9.gif)

![Jun-16-2020 14-39-23](https://user-images.githubusercontent.com/8787187/84831178-b9eb6100-afdf-11ea-886f-dda859e062a4.gif)

Future work: Fix this rendering issue when there's no sprites in either socket
![image](https://user-images.githubusercontent.com/8787187/84831240-d5566c00-afdf-11ea-9e05-c7eb7f31d2f8.png)
This only happens with the touch event block when there's no block in either socket. These all look fine:
![image](https://user-images.githubusercontent.com/8787187/84831278-eacb9600-afdf-11ea-92b8-5c0b6e3d89b6.png)
![image](https://user-images.githubusercontent.com/8787187/84831310-f4ed9480-afdf-11ea-81a3-f12726df8d77.png)
![image](https://user-images.githubusercontent.com/8787187/84831333-f9b24880-afdf-11ea-9946-9035152c7362.png)


