### PR TITLE
[MiniToolbox] Fix rendering issue when mini toolbox blocks are wider than parent block

### DIFF
--- a/core/ui/block_space/horizontal_flyout.js
+++ b/core/ui/block_space/horizontal_flyout.js
@@ -128,6 +128,7 @@ Blockly.HorizontalFlyout.prototype.layoutBlock_ = function(block, cursor, gap,
     offset = -offset;
   }
   cursor.x += offset;
+  this.minFlyoutWidth_ = cursor.x + gap;
   this.height_ = cursor.y + blockHW.height + gap / 2;
 };
 

--- a/core/ui/block_svg/block_svg.js
+++ b/core/ui/block_svg/block_svg.js
@@ -1013,6 +1013,9 @@ Blockly.BlockSvg.prototype.renderCompute_ = function(iconWidth) {
     }
   }
 
+  if (this.block_.miniFlyout && this.block_.miniFlyout.width_) {
+    inputRows.rightEdge = Math.max(inputRows.rightEdge, this.block_.miniFlyout.minFlyoutWidth_)
+  }
   return inputRows;
 };
 


### PR DESCRIPTION
Quick fix to make sure that the block is always wide enough to fit the blocks in its minitoolbox
Screenshots for everything just to show that it works as expected in all cases, but the only one that changed is the touch event when both sockets are empty.
Before:
![image](https://user-images.githubusercontent.com/8787187/84969655-fbf2d080-b0cd-11ea-9304-65c98f8f8e07.png)

After:
![image](https://user-images.githubusercontent.com/8787187/84969562-d2d24000-b0cd-11ea-8754-c9aa7fdae937.png)
