### PR TITLE
Make block highlighting more obvious

### DIFF
--- a/core/ui/css.js
+++ b/core/ui/css.js
@@ -239,6 +239,8 @@ Blockly.Css.CONTENT = [
   '.blocklySelected>.blocklyPath {',
   '  stroke-width: 3px;',
   '  stroke: #fc3;',
+  '  fill: #fc3;',
+  '  fill-opacity: 0.8;',
   '}',
   '.blocklySelected>.blocklyPathLight {',
   '  display: none;',


### PR DESCRIPTION
This makes block highlighting more obvious by making the fill of the block more yellow in addition to the existing yellow border. This highlight applies in all labs when a block is selected/clicked on and in some labs during run.

During run:
![blockhighlight](https://user-images.githubusercontent.com/17147070/85457125-861ab900-b554-11ea-89d8-8411091a544a.gif)

When selected:
<img width="884" alt="Screen Shot 2020-06-23 at 1 24 35 PM" src="https://user-images.githubusercontent.com/17147070/85457401-e3af0580-b554-11ea-9f94-869f11383b0c.png">


- [jira](https://codedotorg.atlassian.net/browse/STAR-1151)