### PR TITLE
Don't update shadow values on mini toolbox blocks when mini toolbox is closed

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1547,15 +1547,17 @@ Blockly.Block.prototype.setParent = function(newParent) {
   }
   if (newParent && newParent.miniFlyout && this.type === 'gamelab_allSpritesWithAnimation') {
     // Add a sprite block to an event socket
-    let miniToolboxBlocks = newParent.miniFlyout.blockSpace_.topBlocks_;
-    let rootInputBlocks = newParent.getConnections_(true /* all */).filter(function(connection) {
-      return connection.type === Blockly.INPUT_VALUE
-    }).map(function(connection) {
-      return connection.targetBlock()
-    });
-    miniToolboxBlocks.forEach(function(block, index) {
-      block.shadowBlockValue_(rootInputBlocks[index]);
-    });
+    if (newParent.isMiniFlyoutOpen) {
+      let miniToolboxBlocks = newParent.miniFlyout.blockSpace_.topBlocks_;
+      let rootInputBlocks = newParent.getConnections_(true /* all */).filter(function(connection) {
+        return connection.type === Blockly.INPUT_VALUE
+      }).map(function(connection) {
+        return connection.targetBlock()
+      });
+      miniToolboxBlocks.forEach(function(block, index) {
+        block.shadowBlockValue_(rootInputBlocks[index]);
+      });
+    }
 
     var shadowBlocks = getShadowBlocksInStack(newParent);
     // We only care about shadow blocks that are shadowing this source block.
@@ -1578,15 +1580,17 @@ Blockly.Block.prototype.setParent = function(newParent) {
   }
   if (oldParent && oldParent.miniFlyout && this.type === 'gamelab_allSpritesWithAnimation') {
     // Remove a sprite block from an event socket
-    let miniToolboxBlocks = oldParent.miniFlyout.blockSpace_.topBlocks_;
-    let rootInputBlocks = oldParent.getConnections_(true /* all */).filter(function(connection) {
-      return connection.type === Blockly.INPUT_VALUE
-    }).map(function(connection) {
-      return connection.targetBlock()
-    });
-    miniToolboxBlocks.forEach(function(block, index) {
-      block.shadowBlockValue_(rootInputBlocks[index]);
-    });
+    if (oldParent.isMiniFlyoutOpen) {
+      let miniToolboxBlocks = oldParent.miniFlyout.blockSpace_.topBlocks_;
+      let rootInputBlocks = oldParent.getConnections_(true /* all */).filter(function(connection) {
+        return connection.type === Blockly.INPUT_VALUE
+      }).map(function(connection) {
+        return connection.targetBlock()
+      });
+      miniToolboxBlocks.forEach(function(block, index) {
+        block.shadowBlockValue_(rootInputBlocks[index]);
+      });
+    }
     
     this.setShadowBlocks([]);
     var shadowBlocks = getShadowBlocksInStack(oldParent);

--- a/core/ui/block_svg/block_svg.js
+++ b/core/ui/block_svg/block_svg.js
@@ -1293,16 +1293,18 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(renderInfo, connectionsXY
     }
     renderInfo.curY += row.height;
   }
-  if (this.block_.tray) {
-    this.block_.miniFlyout.customMetrics = () => ({
-      absoluteTop: renderInfo.curY - 4,
-      absoluteLeft: Blockly.RTL ? -renderInfo.curX : 5,
-      viewWidth: renderInfo.curX - 10
-    });
-    this.block_.miniFlyout.softShow();
-    this.renderDrawTray_(renderInfo, this.block_.miniFlyout.getHeight() + 7);
-  } else if (this.block_.miniFlyout) {
-    this.block_.miniFlyout.softHide();
+  if (this.block_.miniFlyout) {
+    if (this.block_.isMiniFlyoutOpen) {
+      this.block_.miniFlyout.customMetrics = () => ({
+        absoluteTop: renderInfo.curY - 4,
+        absoluteLeft: Blockly.RTL ? -renderInfo.curX : 5,
+        viewWidth: renderInfo.curX - 10
+      });
+      this.block_.miniFlyout.softShow();
+      this.renderDrawTray_(renderInfo, this.block_.miniFlyout.getHeight() + 7);
+    } else {
+      this.block_.miniFlyout.softHide();
+    }
   }
   if (!inputRows.length) {
     renderInfo.curY = BS.MIN_BLOCK_Y;

--- a/tests/playground_requires.js
+++ b/tests/playground_requires.js
@@ -134,14 +134,14 @@ Blockly.Blocks.location_variables_set = createVariableSet(Blockly.BlockValueType
 Blockly.Blocks.parent = {
   init: function() {
     var toggle = new Blockly.FieldIcon('＋');
-    this.tray = false;
+    this.isMiniFlyoutOpen = false;
     Blockly.bindEvent_(toggle.fieldGroup_, 'mousedown', this, () => {
-      if (this.tray) {
+      if (this.isMiniFlyoutOpen) {
         toggle.setText('＋');
       } else {
         toggle.setText('－');
       }
-      this.tray = !this.tray;
+      this.isMiniFlyoutOpen = !this.isMiniFlyoutOpen;
       this.render();
     });
 


### PR DESCRIPTION
There was a rendering issue in some browsers (Firefox, IE, Edge):
![image](https://user-images.githubusercontent.com/8787187/85614663-f63a4500-b60f-11ea-889a-8c70c5ee775d.png)

The root cause is that `getComputedTextLength()` returns 0 if the text element is not visible. So basically, when we updated the object block, the "object" label thought its width was 0, so the preview went on top of it. The solution is to not update the minitoolbox blocks when the flyout is closed, and [this corresponding PR](https://github.com/code-dot-org/code-dot-org/pull/35455) updates them when the flyout opens

This PR also renames `tray` to `isMiniFlyoutOpen`