### PR TITLE
Render minitoolbox properly in embedded/readonly blockspaces

### DIFF
--- a/core/ui/block_space/block_space_editor.js
+++ b/core/ui/block_space/block_space_editor.js
@@ -258,6 +258,14 @@ Blockly.BlockSpaceEditor.prototype.createDom_ = function(container) {
   container.setAttribute('dir', 'LTR');
 
   this.populateSVGEffects_(container);
+  
+  var classes = ['blocklySvg'];
+  if (this.inline_) {
+    classes.push('inline');
+  }
+  if (this.readOnly_) {
+    classes.push('readOnlyBlockSpace');
+  }
 
   // Build the SVG DOM.
   /*
@@ -275,7 +283,7 @@ Blockly.BlockSpaceEditor.prototype.createDom_ = function(container) {
     'xmlns:html': 'http://www.w3.org/1999/xhtml',
     'xmlns:xlink': 'http://www.w3.org/1999/xlink',
     'version': '1.1',
-    'class': this.inline_ ? 'blocklySvg inline' : 'blocklySvg'
+    'class': classes.join(' ')
   }, null);
   this.svg_ = svg;
 
@@ -306,8 +314,6 @@ Blockly.BlockSpaceEditor.prototype.createDom_ = function(container) {
     // Add a handler that allows the workspace to bump blocks back into their
     // working area.
     this.addChangeListener(this.bumpBlocksIfNotDragging);
-  } else {
-    Blockly.addClass_(svg, 'readOnlyBlockSpace');
   }
 
   /**

--- a/core/ui/block_space/block_space_editor.js
+++ b/core/ui/block_space/block_space_editor.js
@@ -306,6 +306,8 @@ Blockly.BlockSpaceEditor.prototype.createDom_ = function(container) {
     // Add a handler that allows the workspace to bump blocks back into their
     // working area.
     this.addChangeListener(this.bumpBlocksIfNotDragging);
+  } else {
+    Blockly.addClass_(svg, 'readOnlyBlockSpace');
   }
 
   /**

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -814,9 +814,14 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
       // Beyond capacity.
       return;
     }
+    var targetBlockSpace = flyout.targetBlockSpace_;
+    if (targetBlockSpace.isReadOnly()) {
+      // Don't create a block in a read only context
+      return;
+    }
+
     // Create the new block by cloning the block in the flyout (via XML).
     var xml = Blockly.Xml.blockToDom(originBlock);
-    var targetBlockSpace = flyout.targetBlockSpace_;
     Blockly.Block.startDragging();
     var block = Blockly.Xml.domToBlock(targetBlockSpace, xml);
     // Place it in the same spot as the flyout copy.
@@ -840,11 +845,9 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
         src = originBlock.inputList[0].titleRow[1].src_;
       }
       if (src != "") {
+        block.inputList[0].titleRow[0].setText(block.shortString);
         block.inputList[0].titleRow[1].setText(originBlock.inputList[0].titleRow[1].src_);  
         block.inputList[0].titleRow[1].updateDimensions_(block.thumbnailSize, block.thumbnailSize);
-      } else {
-        block.inputList[0].titleRow[0].setText(block.longString);
-        block.inputList[0].titleRow[1].updateDimensions_(1, block.thumbnailSize);
       }
     }
     

--- a/core/ui/css.js
+++ b/core/ui/css.js
@@ -174,7 +174,7 @@ Blockly.Css.CONTENT = [
   '#%CONTAINER_ID% .userHidden {',
   '  display: none;',
   '}',
-  '#%CONTAINER_ID% .hiddenFlyout, #blocklyDragCanvas .hiddenFlyout {',
+  '#%CONTAINER_ID% .hiddenFlyout, #blocklyDragCanvas .hiddenFlyout, .readOnlyBlockSpace .hiddenFlyout {',
   '  display: none !important;',
   '}',
   '#%CONTAINER_ID%.edit .userHidden {',


### PR DESCRIPTION
Small fix to hidden flyout render properly in readOnly blockspaces (ie. _not_ render)
Also disallows dragging blocks out of the mini toolbox if it's readOnly

Before:
![image](https://user-images.githubusercontent.com/8787187/85903283-d09d6f00-b7ba-11ea-814c-80a235ccedfd.png)

After:
![image](https://user-images.githubusercontent.com/8787187/85903306-dc893100-b7ba-11ea-8666-141afdcd4477.png)
