### PR TITLE
Run lint on each commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5367,7 +5367,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
-      "optional": true,
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -6101,6 +6100,12 @@
         "mem": "^4.0.0"
       }
     },
+    "os-shim": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
+      "dev": true
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -6407,6 +6412,39 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "pre-commit": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
+      "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^5.0.1",
+        "spawn-sync": "^1.0.15",
+        "which": "1.2.x"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "which": {
+          "version": "1.2.14",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -6496,8 +6534,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "psl": {
       "version": "1.1.31",
@@ -7397,6 +7434,16 @@
       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
       "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
       "dev": true
+    },
+    "spawn-sync": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^1.4.7",
+        "os-shim": "^0.1.2"
+      }
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -8616,8 +8663,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "yargs": {
       "version": "12.0.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "webpack-cli",
     "build:dev": "DEV=1 webpack-cli",
-    "lint": "eslint --fix --ext .js .",
+    "lint": "eslint --ext .js .",
     "preversion": "npm run test",
     "version": "npm run build",
     "postversion": "git push && git push --tags && npm publish",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "test:watch": "karma start",
     "report-coverage": "codecov"
   },
+  "pre-commit": [
+    "lint"
+  ],
   "devDependencies": {
     "codecov": "^3.0.4",
     "eslint": "^6.1.0",
@@ -40,6 +43,7 @@
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^1.1.2",
     "karma-custom": "^1.1.9",
+    "pre-commit": "^1.2.2",
     "prettier": "1.16.1",
     "webpack": "^4.14.0",
     "webpack-cli": "^3.0.8",


### PR DESCRIPTION
To prevent re-introducing lint errors, run full linter on each commit. This doesn't just check changed files, but it's quite fast, so I think there's no harm in running over all files.

![image](https://user-images.githubusercontent.com/8787187/86058545-efe40880-ba15-11ea-8cc8-0537dbb2ba0c.png)
