### PR TITLE
[Mini Toolbox] Set miniflyoutopen in block xml

### DIFF
--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -155,6 +155,10 @@ Blockly.Xml.blockToDom = function(block, ignoreChildBlocks) {
     element.setAttribute('id', block.htmlId);
   }
 
+  if (block.miniFlyout && block.isMiniFlyoutOpen) {
+    element.setAttribute('miniflyoutopen', true);
+  }
+
   // Don't follow connections if we're ignoring child blocks
   if (block.nextConnection && !ignoreChildBlocks) {
     var nextBlock = block.nextConnection.targetBlock();
@@ -407,6 +411,13 @@ Blockly.Xml.domToBlock = function(blockSpace, xmlBlock) {
       block.type,
       parseInt(limit)
     );
+  }
+
+  var isMiniFlyoutOpen = xmlBlock.getAttribute('miniflyoutopen');
+  if (isMiniFlyoutOpen) {
+    block.isMiniFlyoutOpen = isMiniFlyoutOpen === 'true';
+  } else {
+    block.isMiniFlyoutOpen = false;
   }
 
   var blockChild = null;


### PR DESCRIPTION
Levelbuilders want to be able to set the miniflyout to default to open in instructions. Adding it to the block XML will allow this. Incidentally, it means the miniflyout state will also persist when you re-open a project, which is an added benefit.