### PR TITLE
Add support for IDs in block titles

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -224,6 +224,7 @@ Blockly.Block.createProcedureDefinitionBlock = function(config) {
     getProcedureInfo: function() {
       return {
         name: this.getTitleValue('NAME'),
+        id: this.getTitle_('NAME').id,
         parameterNames: this.parameterNames_,
         parameterIDs: this.paramIds_,
         parameterTypes: this.parameterTypes_,

--- a/core/ui/block_space/block_space.js
+++ b/core/ui/block_space/block_space.js
@@ -330,7 +330,12 @@ Blockly.BlockSpace.prototype.findFunction = function(functionName) {
       goog.array.contains(
         Blockly.Procedures.DEFINITION_BLOCK_TYPES,
         block.type
-      ) && Blockly.Names.equals(functionName, block.getTitleValue('NAME'))
+      ) &&
+      Blockly.Names.equals(
+        functionName,
+        // Use title id as function name if present, or title value if not.
+        block.getTitle_('NAME').id || block.getTitleValue('NAME')
+      )
     );
   });
 };

--- a/core/utils/procedures.js
+++ b/core/utils/procedures.js
@@ -291,6 +291,8 @@ Blockly.Procedures.createCallerBlock = function(
     procedureDefinitionInfo.callType
   );
   newCallBlock.setTitleValue(procedureDefinitionInfo.name, title);
+  var title_ = newCallBlock.getTitle_(title);
+  title_.id = procedureDefinitionInfo.id;
   var tempIds = [];
   for (var t = 0; t < procedureDefinitionInfo.parameterNames.length; t++) {
     tempIds[t] = 'ARG' + t;

--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -74,6 +74,9 @@ Blockly.Xml.blockToDom = function(block, ignoreChildBlocks) {
       if (title.config) {
         container.setAttribute('config', title.config);
       }
+      if (title.id) {
+        container.setAttribute('id', title.id);
+      }
       element.appendChild(container);
     }
   }
@@ -448,6 +451,9 @@ Blockly.Xml.domToBlock = function(blockSpace, xmlBlock) {
           block.setFieldConfig(name, config);
         }
         block.setTitleValue(xmlChild.textContent, name);
+        if (xmlChild.id) {
+          block.getTitle_(name).id = xmlChild.id;
+        }
         break;
       case 'value':
         if (!input) {

--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -454,7 +454,10 @@ Blockly.Xml.domToBlock = function(blockSpace, xmlBlock) {
         const title = block.getTitle_(name);
         if (xmlChild.id) {
           title.id = xmlChild.id;
-        } else if (block.type === 'behavior_definition') {
+        } else if (
+          block.type === 'behavior_definition' ||
+          block.type === 'gamelab_behavior_get'
+        ) {
           // If the XML element doesn't have an id, set the title id
           // to match the behavior name. This is needed for backwards
           // compatibility.

--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -451,8 +451,14 @@ Blockly.Xml.domToBlock = function(blockSpace, xmlBlock) {
           block.setFieldConfig(name, config);
         }
         block.setTitleValue(xmlChild.textContent, name);
+        const title = block.getTitle_(name);
         if (xmlChild.id) {
-          block.getTitle_(name).id = xmlChild.id;
+          title.id = xmlChild.id;
+        } else if (block.type === 'behavior_definition') {
+          // If the XML element doesn't have an id, set the title id
+          // to match the behavior name. This is needed for backwards
+          // compatibility.
+          title.id = xmlChild.textContent;
         }
         break;
       case 'value':

--- a/generators/javascript/procedures.js
+++ b/generators/javascript/procedures.js
@@ -30,7 +30,7 @@ goog.require('Blockly.JavaScript');
 Blockly.JavaScript.procedures_defreturn = function() {
   // Define a procedure with a return value.
   var funcName = Blockly.JavaScript.variableDB_.getName(
-    this.getTitleValue('NAME'),
+    this.getTitle_('NAME').id,
     Blockly.Procedures.NAME_TYPE
   );
   // Store names for each of the args

--- a/generators/javascript/procedures.js
+++ b/generators/javascript/procedures.js
@@ -28,9 +28,18 @@ goog.provide('Blockly.JavaScript.procedures');
 goog.require('Blockly.JavaScript');
 
 Blockly.JavaScript.procedures_defreturn = function() {
+  var title = this.getTitle_('NAME');
+  var functionName;
+  if (title.id) {
+    functionName = title.id;
+  } else {
+    // If the title doesn't have an id, use the title value
+    // as the function name.
+    functionName = title.getValue();
+  }
   // Define a procedure with a return value.
   var funcName = Blockly.JavaScript.variableDB_.getName(
-    this.getTitle_('NAME').id,
+    functionName,
     Blockly.Procedures.NAME_TYPE
   );
   // Store names for each of the args

--- a/generators/javascript/procedures.js
+++ b/generators/javascript/procedures.js
@@ -31,6 +31,9 @@ Blockly.JavaScript.procedures_defreturn = function() {
   var title = this.getTitle_('NAME');
   var functionName;
   if (title.id) {
+    // Sprite Lab shared functions use an id field on the title
+    // so that we can translate the block text without changing
+    // the generated code.
     functionName = title.id;
   } else {
     // If the title doesn't have an id, use the title value

--- a/tests/xml_test.js
+++ b/tests/xml_test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+function test_xml_title_with_id() {
+  var container = Blockly.Test.initializeBlockSpaceEditor();
+  var blockSpace = Blockly.mainBlockSpace;
+  var blockXml =
+    '<xml>' +
+    '<block type="gamelab_behavior_get">' +
+    '<mutation></mutation>' +
+    '<title id="growing" name="VAR">growing</title>' +
+    '</block>' +
+    '</xml>';
+  Blockly.Xml.domToBlockSpace(blockSpace, Blockly.Xml.textToDom(blockXml));
+  var block = blockSpace.getTopBlocks()[0];
+  assertEquals(block.getTitle_('VAR').id, 'growing');
+}
+
+function test_xml_title_without_id() {
+  var container = Blockly.Test.initializeBlockSpaceEditor();
+  var blockSpace = Blockly.mainBlockSpace;
+  var blockXml =
+    '<xml>' +
+    '<block type="behavior_definition" >' +
+    '<title name="NAME">growing</title>' +
+    '</block>' +
+    '<block type="gamelab_behavior_get">' +
+    '<title name="VAR">growing</title>' +
+    '</block>' +
+    '</xml>';
+  Blockly.Xml.domToBlockSpace(blockSpace, Blockly.Xml.textToDom(blockXml));
+  var behaviorDefinitionBlock = blockSpace.getTopBlocks()[0];
+  // Adds id to title if block type is behavior_definition
+  assertEquals(behaviorDefinitionBlock.getTitle_('NAME').id, 'growing');
+
+  var otherBlock = blockSpace.getTopBlocks()[1];
+  // Does not add id to title if block type is not behavior_definition
+  assertEquals(otherBlock.getTitle_('VAR').id, undefined);
+}
+
+function test_block_title_with_id() {
+  var containerDiv = Blockly.Test.initializeBlockSpaceEditor();
+  var blockSpace = Blockly.mainBlockSpace;
+
+  var block = new Blockly.Block(blockSpace);
+  block.initSvg();
+  block.setTitleValue('title value', 'VAR');
+  block.getTitle_('VAR').id = 'title id';
+
+  var xml = Blockly.Xml.blockToDom(block);
+  assertEquals(xml.childNodes[0].getAttribute('id'), 'title id');
+}

--- a/tests/xml_test.js
+++ b/tests/xml_test.js
@@ -26,14 +26,21 @@ function test_xml_title_without_id() {
     '<block type="gamelab_behavior_get">' +
     '<title name="VAR">growing</title>' +
     '</block>' +
+    '<block type="another_type">' +
+    '<title name="VAR">growing</title>' +
+    '</block>' +
     '</xml>';
   Blockly.Xml.domToBlockSpace(blockSpace, Blockly.Xml.textToDom(blockXml));
   var behaviorDefinitionBlock = blockSpace.getTopBlocks()[0];
   // Adds id to title if block type is behavior_definition
   assertEquals(behaviorDefinitionBlock.getTitle_('NAME').id, 'growing');
 
-  var otherBlock = blockSpace.getTopBlocks()[1];
-  // Does not add id to title if block type is not behavior_definition
+  var behaviorDefinitionBlock = blockSpace.getTopBlocks()[1];
+  // Adds id to title if block type is gamelab_behavior_get
+  assertEquals(behaviorDefinitionBlock.getTitle_('VAR').id, 'growing');
+
+  var otherBlock = blockSpace.getTopBlocks()[2];
+  // Does not add id to title if block type is not behavior_definition or gamelab_behavior_get
   assertEquals(otherBlock.getTitle_('VAR').id, undefined);
 }
 


### PR DESCRIPTION
Add an ID field to titles that persists across a roundtrip through XML
Before:
![image](https://user-images.githubusercontent.com/8787187/99852724-7076e300-2b36-11eb-8f22-fd10e9b38455.png)

After:
![image](https://user-images.githubusercontent.com/8787187/99852754-7d93d200-2b36-11eb-8cb7-064952df7a02.png)

This will be used for Sprite Lab shared behaviors so that we can generate functions by the id of the block, not the text on the block. This will enable us to translate the block text without changing the underlying function.