### PR TITLE
Temporarily disable CodeCov report and sign new Drone script

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -18,9 +18,10 @@ steps:
 
 trigger:
   branch:
-  - main
+    - main
   event:
-  - pull_request
+    - pull_request
+
 ---
 kind: signature
 hmac: 1c489bf8dcfa89d44d2996b8dab25faee0f970c68eb4725b7e8a30f12c23120f

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,14 +7,14 @@ steps:
   image: circleci/node:6.13-browsers
   pull: always
   environment:
-#    CODECOV_TOKEN:
-#      from_secret: CODECOV_TOKEN
+#   CODECOV_TOKEN:
+#     from_secret: CODECOV_TOKEN
   commands:
    - sudo chown -R circleci:circleci .
    - npm install
    - npm run test:coverage
    # TODO: (suresh) Temporarily disable CodeCov until we provision a new API key.
-#   - npm run report-coverage
+#  - npm run report-coverage
 
 trigger:
   branch:
@@ -24,6 +24,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 1c489bf8dcfa89d44d2996b8dab25faee0f970c68eb4725b7e8a30f12c23120f
+hmac: a5a2f5fe702df5da79b6c7701fd1cf5ea7eec082000ef2160f5cbb1aec15f978
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,13 +7,14 @@ steps:
   image: circleci/node:6.13-browsers
   pull: always
   environment:
-    CODECOV_TOKEN:
-      from_secret: CODECOV_TOKEN
+#    CODECOV_TOKEN:
+#      from_secret: CODECOV_TOKEN
   commands:
    - sudo chown -R circleci:circleci .
    - npm install
    - npm run test:coverage
-   - npm run report-coverage
+   # TODO: (suresh) Temporarily disable CodeCov until we provision a new API key.
+#   - npm run report-coverage
 
 trigger:
   branch:
@@ -22,6 +23,6 @@ trigger:
   - pull_request
 ---
 kind: signature
-hmac: efb1ce4e6b15b2368d17d94ff775016281eb3ea899fb82a55edc29841c70bc0b
+hmac: 1c489bf8dcfa89d44d2996b8dab25faee0f970c68eb4725b7e8a30f12c23120f
 
 ...


### PR DESCRIPTION
When the Drone server was rebuilt 2 months ago we lost the CodeCov.io API key being used by Blockly continuous integration builds to publish code coverage reports. Sign the Drone build script so that it is authenticated by the new Drone server and temporarily disable CodeCov.