### PR TITLE
Keep id and name in sync for user created behaviors

### DIFF
--- a/core/ui/function_editor.js
+++ b/core/ui/function_editor.js
@@ -717,6 +717,9 @@ Blockly.FunctionEditor.prototype.create_ = function() {
       this.container_.querySelector('#functionNameText').value = value;
     }
     this.functionDefinitionBlock.setTitleValue(value, 'NAME');
+    if (this.functionDefinitionBlock.userCreated) {
+      this.functionDefinitionBlock.getTitle_('NAME').id = value;
+    }
   }
 
   Blockly.bindEvent_(this.contractDiv_, 'mousedown', null, function() {


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/blockly/pull/254
This caused a regression for user-created behaviors. [slack thread](https://codedotorg.slack.com/archives/C946FMBGT/p1607385128161900)
Repro Steps:
1. Create a behavior (click create a behavior, change the name, add some blocks to the definition)
![image](https://user-images.githubusercontent.com/8787187/101425968-ed34eb80-38b0-11eb-8c6d-85b3cdec3c27.png)
2. Use the behavior in your program
![image](https://user-images.githubusercontent.com/8787187/101426017-089ff680-38b1-11eb-94ad-da723a0b1c19.png)
3. Click "Create a Behavior" again
Observe that your first behavior definition is still there (it shouldn't be)
![image](https://user-images.githubusercontent.com/8787187/101426074-1bb2c680-38b1-11eb-83ea-aa2e7a88bcab.png)
4. Change the name and definition and click save
![image](https://user-images.githubusercontent.com/8787187/101426136-3c7b1c00-38b1-11eb-8a74-0cf5e707d631.png)

Observe that it changed the first behavior block too
![image](https://user-images.githubusercontent.com/8787187/101426165-4ef55580-38b1-11eb-94b3-f1167c07d483.png)
And now your first behavior is totally gone.

The reason for this is that the first behavior gets id `do something`. Then you change the name (in this case to `my func`), which changes the value on the block, but not the id. Then when you make another function, it *also* has id `do something`, so it clobbers `my func`.

For user created behaviors, we need to keep the `id` and `name` in sync so that we don't clobber behaviors.