### PR TITLE
Fix behavior renaming

### DIFF
--- a/core/ui/function_editor.js
+++ b/core/ui/function_editor.js
@@ -197,6 +197,7 @@ Blockly.FunctionEditor.prototype.openAndEditFunction = function(functionName) {
   if (!targetFunctionDefinitionBlock) {
     throw new Error("Can't find definition block to edit");
   }
+  var functionDisplayName = targetFunctionDefinitionBlock.getTitleValue('NAME');
 
   this.show();
   this.setupUIForBlock_(targetFunctionDefinitionBlock);
@@ -209,7 +210,9 @@ Blockly.FunctionEditor.prototype.openAndEditFunction = function(functionName) {
   this.populateParamToolbox_();
   this.setupUIAfterBlockInEditor_();
 
-  this.container_.querySelector('#functionNameText').value = functionName;
+  this.container_.querySelector(
+    '#functionNameText'
+  ).value = functionDisplayName;
   this.container_.querySelector('#functionDescriptionText').value =
     this.functionDefinitionBlock.description_ || '';
   this.deleteButton_.setVisible(targetFunctionDefinitionBlock.userCreated);

--- a/core/utils/procedures.js
+++ b/core/utils/procedures.js
@@ -186,7 +186,7 @@ Blockly.Procedures.rename = function(text) {
   for (var x = 0; x < blocks.length; x++) {
     var func = blocks[x].renameProcedure;
     if (func) {
-      func.call(blocks[x], this.text_, text);
+      func.call(blocks[x], this.text_, text, this.sourceBlock_.userCreated);
     }
   }
   this.sourceBlock_.blockSpace.blockSpaceEditor.svgResize();


### PR DESCRIPTION
[Bug report](https://www.loom.com/share/f289f0c9292247ee941ca8ded4666282)
There were two small issues:
1. If you rename a shared behavior, we don't change the block id, just the text on the block. However, in the modal editor, we were showing the block id, so it didn't match the expected name. 
Before
![image](https://user-images.githubusercontent.com/8787187/104220128-e6d7e900-53f3-11eb-8f38-5649a885693a.png)

After
![image](https://user-images.githubusercontent.com/8787187/104220039-c871ed80-53f3-11eb-8a06-d1932b0c307b.png)

2. When you rename a user-created behavior, we *do* change the id on the block definition block. However, we need to make sure we also change the associated id on all the existing caller blocks. This resulted in errors the next time you try to open the behavior definition. The fix in the blockly repo is to pass `userCreated` through to the changeHandler when the definition block is renamed. There will be a corresponding change [here](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/p5lab/spritelab/blocks.js#L541) to make it so that we set the id on the caller block if the behavior is user-created
Before
![image](https://user-images.githubusercontent.com/8787187/104220383-42a27200-53f4-11eb-8969-eeb47304ba99.png)
After
![image](https://user-images.githubusercontent.com/8787187/104220502-741b3d80-53f4-11eb-9896-00cf63a09a4c.png)

