### PR TITLE
FND-22: added a condition for positioning inline blocks in RLT context

### DIFF
--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -263,6 +263,10 @@ Blockly.Xml.domToBlockSpace = function(blockSpace, xml) {
   //  otherwise, the block "flows" with the other blocks from top to
   //  bottom. Any block positioned absolutely with Y does not influence
   //  the flow of the other blocks.
+  var cursor = {
+    x: paddingLeft,
+    y: paddingTop
+  };
 
   var positionBlock = function(block) {
     var padding = block.blockly_block.getSvgPadding() || {
@@ -273,11 +277,6 @@ Blockly.Xml.domToBlockSpace = function(blockSpace, xml) {
     };
 
     var heightWidth = block.blockly_block.getHeightWidth();
-
-    var cursor = {
-      x: paddingLeft,
-      y: paddingTop
-    };
 
     if(Blockly.RTL) {
       cursor.x = inline ? heightWidth.width - paddingLeft : width - paddingLeft;

--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -275,13 +275,13 @@ Blockly.Xml.domToBlockSpace = function(blockSpace, xml) {
     var heightWidth = block.blockly_block.getHeightWidth();
 
     var cursor = {
-      x: !Blockly.RTL
-          ? paddingLeft
-          : inline
-            ? heightWidth.width - paddingLeft
-            : width - paddingLeft,
+      x: paddingLeft,
       y: paddingTop
     };
+
+    if(Blockly.RTL) {
+      cursor.x = inline ? heightWidth.width - paddingLeft : width - paddingLeft;
+    }
 
     if (isNaN(block.x)) {
       block.x = cursor.x;

--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -247,6 +247,7 @@ Blockly.Xml.textToDom = function(text) {
 Blockly.Xml.domToBlockSpace = function(blockSpace, xml) {
   var metrics = blockSpace.getMetrics();
   var width = metrics ? metrics.viewWidth : 0;
+  var inline = blockSpace.blockSpaceEditor.inline_;
 
   var paddingLeft = blockSpace.blockSpaceEditor.shouldHavePadding()
     ? Blockly.BlockSpace.AUTO_LAYOUT_PADDING_LEFT
@@ -262,10 +263,6 @@ Blockly.Xml.domToBlockSpace = function(blockSpace, xml) {
   //  otherwise, the block "flows" with the other blocks from top to
   //  bottom. Any block positioned absolutely with Y does not influence
   //  the flow of the other blocks.
-  var cursor = {
-    x: Blockly.RTL ? width - paddingLeft : paddingLeft,
-    y: paddingTop
-  };
 
   var positionBlock = function(block) {
     var padding = block.blockly_block.getSvgPadding() || {
@@ -276,6 +273,15 @@ Blockly.Xml.domToBlockSpace = function(blockSpace, xml) {
     };
 
     var heightWidth = block.blockly_block.getHeightWidth();
+
+    var cursor = {
+      x: !Blockly.RTL
+          ? paddingLeft
+          : inline
+            ? heightWidth.width - paddingLeft
+            : width - paddingLeft,
+      y: paddingTop
+    };
 
     if (isNaN(block.x)) {
       block.x = cursor.x;


### PR DESCRIPTION
FND-22: https://codedotorg.atlassian.net/browse/FND-22?atlOrigin=eyJpIjoiYjExMmNlZGQ0ZjI2NGExZThiNTNiYzQwZGYwZTRjY2QiLCJwIjoiaiJ9

Most blocks were being positioned correctly in RTL context, however, inline blocks found in the instructions pane were often slightly offset and clipping into the regular text. Some blocks are so offset they aren't even visible.

The viewWidth is used to calculate offset in a regular context, but for inline we must use the width of the block itself.

Before:

![image](https://user-images.githubusercontent.com/9528376/112210101-46b6f100-8be8-11eb-9a85-4446bf6d0a7f.png)

After:

![image](https://user-images.githubusercontent.com/9528376/112210444-b036ff80-8be8-11eb-9f86-0ce40cdec136.png)
