### PR TITLE
Don't crop images in field image dropdowns

### DIFF
--- a/core/ui/fields/field_image_dropdown.js
+++ b/core/ui/fields/field_image_dropdown.js
@@ -69,8 +69,7 @@ Blockly.FieldImageDropdown.prototype.addPreviewElementTo_ = function(
     {
       height: Blockly.FieldImage.IMAGE_LOADING_HEIGHT + 'px',
       width: Blockly.FieldImage.IMAGE_LOADING_WIDTH + 'px',
-      y: Blockly.FieldImage.IMAGE_OFFSET_Y,
-      preserveAspectRatio: 'xMidYMid slice'
+      y: Blockly.FieldImage.IMAGE_OFFSET_Y
     },
     parentElement
   );


### PR DESCRIPTION
Unfortunately, I can't find any git history (just [Anybody can learn](https://github.com/code-dot-org/blockly/commit/26a17fd70dc273851d359bed0e24647e94e39eaa)) showing why we had originally wanted `xMidyMid slice`, but I don't think we want this anymore. In sprite lab it leads to suboptimal cropping of images in the sprite dropdown:
Before:
![image](https://user-images.githubusercontent.com/8787187/112343962-dc9e5a80-8c80-11eb-974b-1d9e1d140549.png)

After:
![image](https://user-images.githubusercontent.com/8787187/112343884-c98b8a80-8c80-11eb-9786-6694aa39b775.png)

I checked other places we use the FieldImageDropdown, and it doesn't look like it regresses anything for other labs. I think this is because the rest of our images are already square, so there's no cropping needed.
![image](https://user-images.githubusercontent.com/8787187/112344376-4159b500-8c81-11eb-95e7-79f0fb0749bc.png)
![image](https://user-images.githubusercontent.com/8787187/112345941-bbd70480-8c82-11eb-9c4d-62bc9ad1cf56.png)
![image](https://user-images.githubusercontent.com/8787187/112346011-cbeee400-8c82-11eb-9d68-d5450bedc495.png)
