### PR TITLE
FND-1377 Flyout subject blocks outside display area in RTL

### DIFF
--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -635,6 +635,28 @@ Blockly.Flyout.prototype.show = function(xmlList) {
     this.layoutXmlToBlocks_(xmlList, blocks, gaps, margin);
   }
 
+  // If RTL, calculate the flyout content width
+  // to adjust the cursor, accounting for padding
+  if(Blockly.RTL) {
+    var offsets = [];
+    for (var i = 0, block; (block = blocks[i]); i++) {
+      var blockHW = block.getHeightWidth();
+      if (initialX - blockHW.width < 0){
+        initialX = this.width_;
+      }
+      var offset = blockHW.width + gaps[i] / 2;
+      initialX -= offset;
+      offsets.push(initialX);
+    }
+    var index_min_x = offsets.indexOf(Math.min(...offsets));
+    var min_x = offsets[index_min_x];
+    var rtl_offset = min_x + gaps[index_min_x];
+    var viewWidth = this.targetBlockSpace_.getMetrics().viewWidth;
+    cursor.x = viewWidth - rtl_offset;
+    initialX = cursor.x;
+    this.width_ = cursor.x;
+  }
+
   // Lay out the blocks vertically.
   for (var i = 0, block; (block = blocks[i]); i++) {
     var allBlocks = block.getDescendants();

--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -648,7 +648,7 @@ Blockly.Flyout.prototype.show = function(xmlList) {
       initialX -= offset;
       offsets.push(initialX);
     }
-    var index_min_x = offsets.indexOf(Math.min(...offsets));
+    var index_min_x = offsets.indexOf(Math.min.apply(Math, offsets));
     var min_x = offsets[index_min_x];
     var rtl_offset = min_x + gaps[index_min_x];
     var viewWidth = this.targetBlockSpace_.getMetrics().viewWidth;


### PR DESCRIPTION
FND-1377: https://codedotorg.atlassian.net/browse/FND-1377?atlOrigin=eyJpIjoiOTc2NzRjMjk1NDllNDIzZDkzZTU4NzA4MGY5ZmVhZTIiLCJwIjoiaiJ9

In RTL context, the content of the flyout was positioned out to the right of the container it should be in.

This is likely because that is where it sits while hidden. This is not an issue in LTR context because it doesn't need to know the width of the content before positioning each element. In RTL we do need to know the width of the content before it's actually in the DOM.

To fix the issue, if RTL - we calculate the width of the flyout content before setting the X and Y offset positions.

Before:

![image](https://user-images.githubusercontent.com/9528376/112380145-070b0a80-8cb7-11eb-8d27-f6a247634f05.png)


After:

![image](https://user-images.githubusercontent.com/9528376/112379858-a67bcd80-8cb6-11eb-8ff1-62d811abee88.png)
