### PR TITLE
Refresh previews on image dropdown when animations change

### DIFF
--- a/core/ui/block_space/block_space.js
+++ b/core/ui/block_space/block_space.js
@@ -142,6 +142,12 @@ Blockly.BlockSpace.EVENTS.BLOCK_SPACE_SCROLLED = 'blockSpaceScrolled';
 Blockly.BlockSpace.EVENTS.RUN_BUTTON_CLICKED = 'runButtonClicked';
 
 /**
+ * Fired by Code Studio when animation assets change.
+ * @type {string}
+ */
+Blockly.BlockSpace.EVENTS.ANIMATIONS_CHANGED = 'animationsChanged';
+
+/**
  * Angle away from the horizontal to sweep for blocks.  Order of execution is
  * generally top to bottom, but a small angle changes the scan to give a bit of
  * a left to right bias (reversed in RTL).  Units are in degrees.

--- a/core/ui/fields/field_rectangular_dropdown.js
+++ b/core/ui/fields/field_rectangular_dropdown.js
@@ -502,6 +502,10 @@ Blockly.FieldRectangularDropdown.prototype.getPreviewDataForValue_ = function(
   return null;
 };
 
+Blockly.FieldRectangularDropdown.prototype.onAnimationsChanged = function() {
+  this.refreshPreview_();
+};
+
 /**
  * Install this field on a block
  *  * @param {!Blockly.Block} block The block containing this field.
@@ -511,6 +515,12 @@ Blockly.FieldRectangularDropdown.prototype.init = function(block) {
     throw 'Field has already been initialized once.';
   }
   this.sourceBlock_ = block;
+  this.sourceBlock_.blockSpace.events.listen(
+    Blockly.BlockSpace.EVENTS.ANIMATIONS_CHANGED,
+    this.onAnimationsChanged,
+    false,
+    this
+  );
   this.sourceBlock_.getSvgRoot().appendChild(this.fieldGroup_);
   this.mouseUpWrapper_ = Blockly.bindEvent_(
     this.getClickTarget(),


### PR DESCRIPTION
Update preview field on rectangular dropdowns when custom event `ANIMATIONS_CHANGE` is fired. This event will be fired only from Sprite Lab, so it will not affect any of our other Blockly environments.
![image](https://user-images.githubusercontent.com/8787187/112530084-42631300-8d63-11eb-8a1c-052cad7bde98.png)

Corresponding code-dot-org PR: https://github.com/code-dot-org/code-dot-org/pull/39724