### PR TITLE
FND 1487 Unexpected RTL Behavior

### DIFF
--- a/core/ui/css.js
+++ b/core/ui/css.js
@@ -255,6 +255,7 @@ Blockly.Css.CONTENT = [
   '  left: -1px;',
   '  border: 1px solid #fff;',
   '  z-index: 10;',
+  '  direction: ltr;',
   '}',
   '#blocklyDragCanvas.isDragging {',
   '  display: block;',

--- a/core/ui/fields/field_dropdown.js
+++ b/core/ui/fields/field_dropdown.js
@@ -181,11 +181,9 @@ Blockly.FieldDropdown.prototype.positionWidgetDiv = function() {
   }
 
   if (Blockly.RTL) {
-    xy.x += borderBBox.width;
-    xy.x += Blockly.FieldDropdown.CHECKMARK_OVERHANG; // Width of checkmark.
     // Don't go offscreen left.
-    if (xy.x < scrollOffset.x + menuSize.width) {
-      xy.x = scrollOffset.x + menuSize.width;
+    if (xy.x < scrollOffset.x) {
+      xy.x = scrollOffset.x + Blockly.FieldDropdown.CHECKMARK_OVERHANG;
     }
   } else {
     xy.x -= Blockly.FieldDropdown.CHECKMARK_OVERHANG; // Width of checkmark.


### PR DESCRIPTION
FND-1487: https://codedotorg.atlassian.net/browse/FND-1487?atlOrigin=eyJpIjoiYjhiNWEwNzU0MjE5NDI3OWFkYzQyY2M4ZGQyNDZjZDgiLCJwIjoiaiJ9

While dragging a block in RTL, text and other elements become misaligned. To fix this, the blocklyDragSpace must be explicitly set to _LTR_ so that the coordinate's in the main block space and the drag block space align.

BEFORE:

![ed952e7e-6aa2-4183-8972-d31b9632c10b](https://user-images.githubusercontent.com/9528376/112697389-6a32a380-8e55-11eb-8b83-7a1aaf8f6e2c.gif)


AFTER:

https://user-images.githubusercontent.com/9528376/112697318-48392100-8e55-11eb-9562-12196e1a4e35.mov

62fc.gif)


Dropdown menus on RTL blocks are incorrectly positioned. There was some RTL specific code here already, but it was not following the right assumptions about RTL positioning. Perhaps it used to work, but some other RTL change caused this.

BEFORE:


![image](https://user-images.githubusercontent.com/9528376/112697689-1d030180-8e56-11eb-8fb9-3e89ed037c05.png)


AFTER:


<img width="355" alt="RTLdropdown" src="https://user-images.githubusercontent.com/9528376/112697695-21c7b580-8e56-11eb-8f95-a32ba7b8d10f.png">