### PR TITLE
[Sprite Lab] Force buttons in rectangular dropdown to a new row

### DIFF
--- a/core/ui/fields/field_rectangular_dropdown.js
+++ b/core/ui/fields/field_rectangular_dropdown.js
@@ -231,12 +231,34 @@ Blockly.FieldRectangularDropdown.prototype.showMenu_ = function() {
     this.generateMenuItemSelectedHandler_()
   );
   if (this.buttons_) {
-    for (var i = 0; i < this.buttons_.length; i++) {
+    // Force buttons to a new row by adding blank elements if needed
+    var items = this.menu_.getChildCount();
+    var columns = chooseNumberOfColumns(items);
+    var numInLastRow = items % columns;
+    var numBlankToAdd = 0;
+    if (numInLastRow > 0) {
+      numBlankToAdd = columns - numInLastRow;
+    }
+    var i;
+    for (i = 0; i < numBlankToAdd; i++) {
+      this.addBlankMenuItem_();
+    }
+
+    for (i = 0; i < this.buttons_.length; i++) {
       this.addMenuButton_(this.buttons_[i]);
     }
   }
   this.addPositionAndShowMenu(this.menu_);
   this.pointArrowUp_();
+};
+
+Blockly.FieldRectangularDropdown.prototype.addBlankMenuItem_ = function() {
+  var item = document.createElement('div');
+  item.style.width = this.previewSize_.width + 'px';
+  item.style.height = this.previewSize_.height + 'px';
+  var menuItem = new goog.ui.MenuItem(item);
+  menuItem.setEnabled(false);
+  this.menu_.addItem(menuItem);
 };
 
 Blockly.FieldRectangularDropdown.prototype.addMenuButton_ = function(


### PR DESCRIPTION
Buttons in the sprite dropdown menu are treated the same as the sprite images (they're all just `MenuItem`s)
This could lead to some awkward looking placement depending on the number of sprites:
Before
![image](https://user-images.githubusercontent.com/8787187/125707214-3564c9f7-4358-47f1-865c-a5a243a2ea16.png)
![image](https://user-images.githubusercontent.com/8787187/125707226-a3a2b0d3-fe7a-430e-9dc0-6e4a484d8479.png)

My solution here is to add empty, unselectable menu items to fill out the row in order to force the buttons to start on a new line:
After
![image](https://user-images.githubusercontent.com/8787187/125707236-605e8a28-f4c0-4402-87e0-395f443f991a.png)
![image](https://user-images.githubusercontent.com/8787187/125707266-0ba3110a-7c5f-4802-bb99-0385f0fe9579.png)

This was the cleanest approach I could come up with, but if there's a better way, please lmk!