### PR TITLE
[Mini toolbox] Only re-render the event stack, not the whole blockspace

### DIFF
--- a/core/ui/block.js
+++ b/core/ui/block.js
@@ -1694,7 +1694,7 @@ Blockly.Block.prototype.setParent = function(newParent) {
       sourceBlock = block.blockToShadow_(block.getRootBlock());
       block.shadowBlockValue_(sourceBlock);
     });
-    this.blockSpace.render();
+    newParent.render();
   } else if (newParent && newParent.getRootBlock().miniFlyout) {
     // Add a block stack to an event stack
     shadowBlocks = getShadowBlocksInStack(this);


### PR DESCRIPTION
When we add a new sprite block to the event socket, we need to update the thumbnails on any pointer blocks in the event stack. Previously, we accomplished this by re-rendering the whole blockspace, which does work, but is a lot of extra work and was a performance issue. Instead, we should just be re-rendering the event block (which also re-renders its children)

Thumbnails still update as expected:
![image](https://user-images.githubusercontent.com/8787187/127555541-d0e6fde5-2d5a-477d-8ec7-8a8af1643a92.png)
