### PR TITLE
Only render visible blocks

### DIFF
--- a/core/ui/block_space/block_space.js
+++ b/core/ui/block_space/block_space.js
@@ -727,7 +727,7 @@ Blockly.BlockSpace.prototype.clear = function() {
  * Render all blocks this blockSpace.
  */
 Blockly.BlockSpace.prototype.render = function() {
-  var renderList = this.getAllBlocks();
+  var renderList = this.getAllVisibleBlocks();
   for (var x = 0, block; x < renderList.length; x++) {
     block = renderList[x];
     if (!block.getChildren().length) {


### PR DESCRIPTION
Small performance improvement to only render visible blocks. This should not result in any user-visible changes since invisible blocks shouldn't be visible anyways.

There will be a corresponding change in the code-dot-org repo to make sure spritelab behavior definition blocks are marked as not user visible, so we don't have to render them.