### PR TITLE
Serialize to <field> and deserialize from <field>

### DIFF
--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -69,7 +69,14 @@ Blockly.Xml.blockToDom = function(block, ignoreChildBlocks) {
   }
   function titleToDom(title) {
     if (title.name && title.EDITABLE) {
-      var container = goog.dom.createDom('title', null, title.getValue());
+      /**
+       * <title> was renamed to <field> in Google Blockly in 2013.
+       * By creating <field> elements here as well, we will make it easier to
+       * migrate to using Google Blockly everywhere.
+       * Both Google Blockly and this fork will still be able to deserialize
+       * block XML that has <title> tags.
+       */
+      var container = goog.dom.createDom('field', null, title.getValue());
       container.setAttribute('name', title.name);
       if (title.config) {
         container.setAttribute('config', title.config);
@@ -444,6 +451,9 @@ Blockly.Xml.domToBlock = function(blockSpace, xmlBlock) {
         }
         break;
       case 'title':
+      // title was renamed to field. See comment in titleToDom for more detail.
+      // fall through
+      case 'field':
         /**
          * XML example:
          * <block type="draw_move_by_constant">

--- a/tests/block_space_test.js
+++ b/tests/block_space_test.js
@@ -450,7 +450,7 @@ function test_locked_serialization() {
     '<xml>' +
     '<block type="text_print"></block>' +
     '<block type="text">' +
-    '<title name="TEXT"></title>' +
+    '<field name="TEXT"></field>' +
     '</block>' +
     '</xml>';
   Blockly.Xml.domToBlockSpace(

--- a/tests/xml_test.js
+++ b/tests/xml_test.js
@@ -56,3 +56,30 @@ function test_block_title_with_id() {
   var xml = Blockly.Xml.blockToDom(block);
   assertEquals(xml.childNodes[0].getAttribute('id'), 'title id');
 }
+
+function test_serialize_field() {
+  var containerDiv = Blockly.Test.initializeBlockSpaceEditor();
+  var blockSpace = Blockly.mainBlockSpace;
+
+  var block = new Blockly.Block(blockSpace, 'text');
+  block.initSvg();
+  block.setTitleValue('field value', 'TEXT');
+  block.getTitle_('TEXT').id = 'field id';
+  var xmlString = Blockly.Xml.domToText(Blockly.Xml.blockToDom(block));
+  var expectedXml =
+    '<block type="text"><field name="TEXT" id="field id">field value</field></block>';
+  assertEquals(xmlString, expectedXml);
+}
+
+function test_deserialize_field() {
+  var container = Blockly.Test.initializeBlockSpaceEditor();
+  var blockSpace = Blockly.mainBlockSpace;
+  var blockXml =
+    '<xml>' +
+    '<block type="text"><field name="TEXT" id="field id">field value</field></block>' +
+    '</xml>';
+  Blockly.Xml.domToBlockSpace(blockSpace, Blockly.Xml.textToDom(blockXml));
+  var block = blockSpace.getTopBlocks()[0];
+  assertEquals(block.getTitleValue('TEXT'), 'field value');
+  assertEquals(block.getTitle_('TEXT').id, 'field id');
+}


### PR DESCRIPTION
This change in the fork will facilitate migration to Google Blockly. Google Blockly renamed `<title>` to `<field>` in 2013. Currently, we have an override in our Google Blockly wrapper layer to make sure we still serialize XML using `<title>` tags [here](https://github.com/code-dot-org/code-dot-org/blob/staging-next/apps/src/blockly/addons/cdoXml.js#L30)
Instead, we should change our fork to match Google Blockly's behavior. With this change, Cdo Blockly will serialize XML using `<field>` tags, and then we can remove the override of `fieldToDom_` to that Google Blockly also serializes using `<field>` tags. Both versions of Blockly will still be able to deserialize XML that uses `<title>` tags, which is important for backwards compatibility.

Before
![image](https://user-images.githubusercontent.com/8787187/144672249-4078342a-ac49-49e6-adc7-3cb9d47d1266.png)

After
![image](https://user-images.githubusercontent.com/8787187/144672155-05b74789-868e-4764-93d4-172b776ee591.png)
Import from XML still works with `<title>` elements
![image](https://user-images.githubusercontent.com/8787187/144672373-a6e6dadb-8819-4779-939b-afbd1f13d195.png)
Import from XML also works with `<field>` elements
![image](https://user-images.githubusercontent.com/8787187/144672456-f850140d-2436-4d89-a077-a00043d718f3.png)

