### PR TITLE
Serialize mini-toolbox state

### DIFF
--- a/core/utils/xml.js
+++ b/core/utils/xml.js
@@ -67,6 +67,11 @@ Blockly.Xml.blockToDom = function(block, ignoreChildBlocks) {
       element.appendChild(mutation);
     }
   }
+
+  if (block.miniFlyoutBlocks && block.isMiniFlyoutOpen) {
+    element.setAttribute('miniFlyout', 'open');
+  }
+
   function titleToDom(title) {
     if (title.name && title.EDITABLE) {
       /**
@@ -422,6 +427,11 @@ Blockly.Xml.domToBlock = function(blockSpace, xmlBlock) {
       block.type,
       parseInt(limit)
     );
+  }
+  var miniFlyout = xmlBlock.getAttribute('miniflyout');
+  if (miniFlyout == 'open') {
+    block.isMiniFlyoutOpen = true;
+    block.setTitleValue('-', 'toggle');
   }
 
   var blockChild = null;


### PR DESCRIPTION
Requires the change in https://github.com/code-dot-org/code-dot-org/pull/44153

Before (mini toolbox is always closed on initial page load)
![image](https://user-images.githubusercontent.com/8787187/147969796-3ca9d0c0-fcb8-4fd9-9378-fc49d6287c8a.png)

After (mini toolbox starts open if it was open when you saved)
![image](https://user-images.githubusercontent.com/8787187/147969687-050ca2d5-2908-4044-bccb-e3b45ee2fb9b.png)
