### PR TITLE
fix(i18n): refactor get_json() to use with open()

### DIFF
--- a/i18n/status.py
+++ b/i18n/status.py
@@ -55,11 +55,8 @@ def get_json(filename):
   Returns:
       A dictionary mapping each JSON key to its value.
   """
-  try:
-    f = open(filename)
+  with open(filename) as f:
     return json.load(f)
-  finally:
-    f.close()
 
 
 def get_prefix_count(prefix, arr):


### PR DESCRIPTION
PEP343 introduces the "with" statement in order to make try finally statements obsolete. this pull request replaces the usage of try finally in get_json() with a with statement, which can be done safely as the try finally statement is only used to ensure the resource is closed.