### PR TITLE
Fix flyout scrolling exception

### DIFF
--- a/core/ui/block_space/flyout.js
+++ b/core/ui/block_space/flyout.js
@@ -281,6 +281,12 @@ Blockly.Flyout.prototype.getHeight = function() {
  */
 Blockly.Flyout.prototype.setMetrics_ = function(yRatio) {
   var metrics = this.getMetrics_();
+
+  // If the flyout is now hidden, don't do anything else.
+  if (metrics === null) {
+    return;
+  }
+
   if (goog.isNumber(yRatio.y)) {
     // TODO(bjordan+bbuchanan): needs to change?
     this.blockSpace_.yOffsetFromView =


### PR DESCRIPTION
Our site's top JS error is currently this:

```
Uncaught TypeError: Cannot read properties of null (reading 'contentHeight')
    at Blockly.Flyout.setMetrics_
    at blockly.js
    at Blockly.BlockSpace.setMetrics
    at Blockly.ScrollbarSvg.onScroll_ 
    at Blockly.ScrollbarSvg.onMouseMoveKnob_ 
```

After acquiring a mouse this afternoon, the repro turned out to be this:
- open a flyout
- hover over scroll bar 
- hold down left mouse button to adjust scroll bar
- move mouse to the right of the flyout
- hold down right mouse button and flyout dismisses
- while both mouse buttons are still held down, move the mouse up and down
- the exception fires each time the mouse is moved

The fix is simple, and doesn't go too deep, but since `getMetrics_` explicitly [returns](https://github.com/code-dot-org/blockly/blob/f755ad36b1b4c0192a708ebad4bf081657447f0b/core/ui/block_space/flyout.js#L235-L238) a `null` when the flyout is no longer visible, it seems reasonable to make an early exit.
