### PR TITLE
Update grid columns for rectangular dropdown

### DIFF
--- a/core/ui/fields/field_rectangular_dropdown.js
+++ b/core/ui/fields/field_rectangular_dropdown.js
@@ -313,10 +313,8 @@ Blockly.FieldRectangularDropdown.prototype.createMenuWithChoices_ = function(
 };
 
 function chooseNumberOfColumns(numItems) {
-  if (numItems <= 7) {
-    return 1;
-  }
-  return Math.floor(Math.sqrt(numItems));
+  // Minimum of 4, maximum of square root of item count.
+  return Math.max(4, Math.floor(Math.sqrt(numItems)));
 }
 
 Blockly.FieldRectangularDropdown.prototype.generateMenuItemSelectedHandler_ = function() {


### PR DESCRIPTION
`FieldRectangularDropdown` is a Blockly field type that is used to create a grid of options, usually square image thumbnails. With many options, we use a square root to create a close-to-square-shaped array. Today, the minimum number of columns is 1. In Sprite Lab, we extend this class for the `costumePicker` and `backgroundPicker` field types. These fields each add a button to help with student management of animations.

**Current Block Examples**
![image](https://user-images.githubusercontent.com/43474485/213477468-e3db2591-9800-4448-a5f9-f5e07a7cbbb2.png)![image](https://user-images.githubusercontent.com/43474485/213478212-ed98c21b-023d-49af-a3c8-5d797b3a989f.png)![image](https://user-images.githubusercontent.com/43474485/213478276-5a93d690-fd45-4133-96bb-573363af358c.png)![image](https://user-images.githubusercontent.com/43474485/213478305-ba2bdba4-c3e3-430e-a121-724b4ee733de.png)




Soon, we will be adding the ability for users to manage their background animations in Sprite Lab, including delete animations for the first time. [[Jira](https://codedotorg.atlassian.net/browse/SL-516)] 
With fewer animations listed, it will be possible for the button to extend beyond the width of the button. The text on the block will change from "more" to "backgrounds" which will make this happen even with the default project animations.


**Anticipated Problem:**
![image](https://user-images.githubusercontent.com/43474485/213477548-376062b6-fd8c-4b3b-ac78-01852dfbcdd4.png)

This change sets the minimum number of columns to 4 as a quick fix, preferred over a more involved field style update in our CDO Blockly branch. 

**After Change:**
![image](https://user-images.githubusercontent.com/43474485/213478050-264c00af-31b2-4c8d-b86b-f70f18318bef.png)![image](https://user-images.githubusercontent.com/43474485/213478478-f44c4be2-3744-4bd5-8741-8e1feeac35da.png)![image](https://user-images.githubusercontent.com/43474485/213478516-6140cba4-c3e8-4c65-8172-e51fb09f4538.png)![image](https://user-images.githubusercontent.com/43474485/213478568-e5d7b74e-d7ff-4fe6-8b72-aa69a08db259.png)


This does change the arrangement of some other blocks, but only slightly. Most blocks already have four columns and are unimpacted.