### PR TITLE
[Student Learning] [SL-207] Fix Custom behavior dialog's green background being misplaced

### DIFF
--- a/core/ui/function_editor.js
+++ b/core/ui/function_editor.js
@@ -1039,6 +1039,7 @@ Blockly.FunctionEditor.prototype.setupParametersToolbox_ = function() {
 };
 
 Blockly.FunctionEditor.prototype.addEditorFrame_ = function() {
+  var noToolboxPadMagicNumber = 36;
   // if we are in readOnly mode, don't pad. Otherwise, pad left
   // based on the size of either the Toolbox or the Flyout
   var left = this.modalBlockSpace.isReadOnly()
@@ -1046,9 +1047,7 @@ Blockly.FunctionEditor.prototype.addEditorFrame_ = function() {
     : Blockly.hasCategories
     ? goog.dom.getElementByClass('blocklyToolboxDiv').getBoundingClientRect()
         .width
-    : goog.dom
-        .getElementByClass('blocklyFlyoutBackground')
-        .getBoundingClientRect().width;
+    : noToolboxPadMagicNumber;
   var top = 0;
   this.frameBase_ = Blockly.createSvgElement(
     'rect',


### PR DESCRIPTION
### [Student Learning] [SL-20 7] Fix Custom behavior dialog's green background being misplaced

Before:
<img width="1677" alt="Знімок екрана 2023-02-24 о 19 20 59" src="https://user-images.githubusercontent.com/22244040/221246127-90146207-9028-4c27-8f93-1d3ae6769cca.png">
<img width="1677" alt="Знімок екрана 2023-02-24 о 19 17 29" src="https://user-images.githubusercontent.com/22244040/221246177-42c5d6b5-b72b-4c69-b5cb-8780d620e284.png">

After:
<img width="1677" alt="Знімок екрана 2023-02-24 о 19 16 34" src="https://user-images.githubusercontent.com/22244040/221246228-9661c33f-9898-4f09-8475-93270ce82be1.png">
<img width="1677" alt="Знімок екрана 2023-02-24 о 19 17 47" src="https://user-images.githubusercontent.com/22244040/221246257-6484b35a-ca4f-4635-baed-5592af6d6242.png">
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/22244040/221616893-41b41b7b-b3fb-44af-bd93-a4a36765a443.png">

- jira ticket: [SL-207](https://codedotorg.atlassian.net/browse/SL-207?atlOrigin=eyJpIjoiMTY3NWQ0ZDI5OTllNDVhYmI5NjAxMzI3MzJhMzFlZDUiLCJwIjoiaiJ9)