### PR TITLE
Fix function editor frame

### DIFF
--- a/core/ui/function_editor.js
+++ b/core/ui/function_editor.js
@@ -1047,7 +1047,15 @@ Blockly.FunctionEditor.prototype.addEditorFrame_ = function() {
     : Blockly.hasCategories
     ? goog.dom.getElementByClass('blocklyToolboxDiv').getBoundingClientRect()
         .width
+    : Blockly.mainBlockSpace.blockSpaceEditor.getToolboxWidth()
+    ? goog.dom
+        .getElementByClass('blocklyFlyoutBackground')
+        .getBoundingClientRect().width
     : noToolboxPadMagicNumber;
+
+  console.log('BLOCKLY CONSOLE:');
+  console.log(Blockly.mainBlockSpace.blockSpaceEditor.getToolboxWidth());
+
   var top = 0;
   this.frameBase_ = Blockly.createSvgElement(
     'rect',

--- a/core/ui/function_editor.js
+++ b/core/ui/function_editor.js
@@ -1039,23 +1039,19 @@ Blockly.FunctionEditor.prototype.setupParametersToolbox_ = function() {
 };
 
 Blockly.FunctionEditor.prototype.addEditorFrame_ = function() {
-  var noToolboxPadMagicNumber = 36;
+  var noToolboxPad =
+    Blockly.modalBlockSpace.getMetrics().absoluteLeft -
+    FRAME_MARGIN_SIDE -
+    Blockly.Bubble.BORDER_WIDTH -
+    1;
   // if we are in readOnly mode, don't pad. Otherwise, pad left
   // based on the size of either the Toolbox or the Flyout
+  var toolboxWidth = Blockly.mainBlockSpace.blockSpaceEditor.getToolboxWidth();
   var left = this.modalBlockSpace.isReadOnly()
     ? 0
-    : Blockly.hasCategories
-    ? goog.dom.getElementByClass('blocklyToolboxDiv').getBoundingClientRect()
-        .width
-    : Blockly.mainBlockSpace.blockSpaceEditor.getToolboxWidth()
-    ? goog.dom
-        .getElementByClass('blocklyFlyoutBackground')
-        .getBoundingClientRect().width
-    : noToolboxPadMagicNumber;
-
-  console.log('BLOCKLY CONSOLE:');
-  console.log(Blockly.mainBlockSpace.blockSpaceEditor.getToolboxWidth());
-
+    : toolboxWidth
+    ? toolboxWidth
+    : noToolboxPad;
   var top = 0;
   this.frameBase_ = Blockly.createSvgElement(
     'rect',


### PR DESCRIPTION
Fixes a regression introduced with:
- https://github.com/code-dot-org/blockly/pull/311

In this earlier attempt, we missed missed testing on levels with uncategorized toolboxes. We can simplify the conditional logic here by taking advantage of the `getToolboxWidth()` function, which accounts for both categorized toolboxes and uncategorized toolbox flyouts.

While I didn't completely find the root cause, I did notice that levels with the initial bug (ie. no toolbox) seem to have a 35px left margin around the workspace. Rather than supplying a magic number to offset this, we can copy and reverse the logic from elsewhere in this file (https://github.com/code-dot-org/blockly/pull/313/files#diff-4ff6b9e5f7876be3c59c337954adb3dff05139647ac8da4fe4cff96fa672e531R595-R596). 
Interestingly, we also learned that the initial bug was happening only in levels where:
* no toolbox is present
* instructions include an embedded block with a mini-toolbox (e.g. `whenTouches`)

This is because that block includes its own element of class `blocklyFlyoutBackground`: 
<img width="888" alt="image" src="https://user-images.githubusercontent.com/43474485/223434715-1d95ae73-afb0-400b-98c2-2878bc7c3225.png">
Before any fixes were made, we used the width above to determine the placement of the function editor frame. With the first solution (https://github.com/code-dot-org/blockly/pull/311), we replaced this width with a magic number that seemed to fix things. Because this number was getting used in any levels without categories, it was actually breaking levels that had toolboxes that were not categorized.