### PR TITLE
Simplify logic for function editor frame

### DIFF
--- a/core/ui/function_editor.js
+++ b/core/ui/function_editor.js
@@ -1039,19 +1039,16 @@ Blockly.FunctionEditor.prototype.setupParametersToolbox_ = function() {
 };
 
 Blockly.FunctionEditor.prototype.addEditorFrame_ = function() {
-  var noToolboxPad =
+  var toolboxPad =
     Blockly.modalBlockSpace.getMetrics().absoluteLeft -
     FRAME_MARGIN_SIDE -
     Blockly.Bubble.BORDER_WIDTH -
     1;
   // if we are in readOnly mode, don't pad. Otherwise, pad left
-  // based on the size of either the Toolbox or the Flyout
-  var toolboxWidth = Blockly.mainBlockSpace.blockSpaceEditor.getToolboxWidth();
-  var left = this.modalBlockSpace.isReadOnly()
-    ? 0
-    : toolboxWidth
-    ? toolboxWidth
-    : noToolboxPad;
+  // based on the logic above.
+  // Previously we just used the size of either the Toolbox or the Flyout
+  // but this was causing problems in levels with blocks with their own flyouts.
+  var left = this.modalBlockSpace.isReadOnly() ? 0 : toolboxPad;
   var top = 0;
   this.frameBase_ = Blockly.createSvgElement(
     'rect',


### PR DESCRIPTION
Addresses this eyes diff:
<img width="1410" alt="Screenshot 2023-03-07 at 11 16 17 AM" src="https://user-images.githubusercontent.com/43474485/223548551-2b67dd4a-f50f-433e-a3f9-751638161f22.png">

In the above case, we couldn't use `getToolboxWidth()`, because it turns out that it's calculated while the Variables flyout is still open. However, the new logic we were using to set the padding for levels without a toolbox actually works just fine even when we do have one!

Fix history:
* https://github.com/code-dot-org/blockly/pull/311
* https://github.com/code-dot-org/blockly/pull/314

The most recent attempt to fix the function editor frame introduced yet another new regression - this time in CSinAlg, which I didn't think to test manually. As a result, I reverted a Blockly bump in our cdo repo. Once this fix is merged, I will publish a new patch version and bump to that instead.