### PR TITLE
CT-175: Stop using function ids for function definitions

### DIFF
--- a/core/ui/function_editor.js
+++ b/core/ui/function_editor.js
@@ -782,7 +782,8 @@ Blockly.FunctionEditor.prototype.create_ = function() {
       this.container_.querySelector('#functionNameText').value = value;
     }
     this.functionDefinitionBlock.setTitleValue(value, 'NAME');
-    if (this.functionDefinitionBlock.type === 'behavior_definition') {
+    console.log("this.functionDefinitionBlock.type", this.functionDefinitionBlock.type);
+    if (this.functionDefinitionBlock.userCreated && this.functionDefinitionBlock.type === 'behavior_definition') {
       this.functionDefinitionBlock.getTitle_('NAME').id = value;
     }
     if (Blockly.Blocks.gamelab_behaviorPicker) {

--- a/core/ui/function_editor.js
+++ b/core/ui/function_editor.js
@@ -782,6 +782,9 @@ Blockly.FunctionEditor.prototype.create_ = function() {
       this.container_.querySelector('#functionNameText').value = value;
     }
     this.functionDefinitionBlock.setTitleValue(value, 'NAME');
+    if (this.functionDefinitionBlock.type === 'behavior_definition') {
+      this.functionDefinitionBlock.getTitle_('NAME').id = value;
+    }
     if (Blockly.Blocks.gamelab_behaviorPicker) {
       var behaviorId = this.functionDefinitionBlock.getTitle_('NAME').id;
       var behaviorPickerBlocks = getAllBehaviorPickerBlocks();
@@ -1093,9 +1096,6 @@ Blockly.FunctionEditor.prototype.onDeleteConfirmed = function(functionName) {
   examples.concat(functionDefinition).forEach(function(block) {
     block.dispose(false, false, true);
   });
-  if (this.functionDefinitionBlock.type === 'behavior_definition') {
-    this.functionDefinitionBlock.getTitle_('NAME').id = value;
-  }
   if (Blockly.Blocks.gamelab_behaviorPicker) {
     var behaviorPickerBlocks = getAllBehaviorPickerBlocks();
     behaviorPickerBlocks.forEach(function(block) {

--- a/core/ui/function_editor.js
+++ b/core/ui/function_editor.js
@@ -782,7 +782,6 @@ Blockly.FunctionEditor.prototype.create_ = function() {
       this.container_.querySelector('#functionNameText').value = value;
     }
     this.functionDefinitionBlock.setTitleValue(value, 'NAME');
-    console.log("this.functionDefinitionBlock.type", this.functionDefinitionBlock.type);
     if (this.functionDefinitionBlock.userCreated && this.functionDefinitionBlock.type === 'behavior_definition') {
       this.functionDefinitionBlock.getTitle_('NAME').id = value;
     }

--- a/core/ui/function_editor.js
+++ b/core/ui/function_editor.js
@@ -782,9 +782,6 @@ Blockly.FunctionEditor.prototype.create_ = function() {
       this.container_.querySelector('#functionNameText').value = value;
     }
     this.functionDefinitionBlock.setTitleValue(value, 'NAME');
-    if (this.functionDefinitionBlock.userCreated) {
-      this.functionDefinitionBlock.getTitle_('NAME').id = value;
-    }
     if (Blockly.Blocks.gamelab_behaviorPicker) {
       var behaviorId = this.functionDefinitionBlock.getTitle_('NAME').id;
       var behaviorPickerBlocks = getAllBehaviorPickerBlocks();

--- a/core/ui/function_editor.js
+++ b/core/ui/function_editor.js
@@ -1093,6 +1093,9 @@ Blockly.FunctionEditor.prototype.onDeleteConfirmed = function(functionName) {
   examples.concat(functionDefinition).forEach(function(block) {
     block.dispose(false, false, true);
   });
+  if (this.functionDefinitionBlock.type === 'behavior_definition') {
+    this.functionDefinitionBlock.getTitle_('NAME').id = value;
+  }
   if (Blockly.Blocks.gamelab_behaviorPicker) {
     var behaviorPickerBlocks = getAllBehaviorPickerBlocks();
     behaviorPickerBlocks.forEach(function(block) {

--- a/generators/javascript/procedures.js
+++ b/generators/javascript/procedures.js
@@ -30,8 +30,8 @@ goog.require('Blockly.JavaScript');
 Blockly.JavaScript.procedures_defreturn = function() {
   var title = this.getTitle_('NAME');
   var functionName;
-  if (title.id) {
-    // Sprite Lab shared functions use an id field on the title
+  if (title.id && this.type === 'behavior_definition') {
+    // Sprite Lab shared behaviors use an id field on the title
     // so that we can translate the block text without changing
     // the generated code.
     functionName = title.id;


### PR DESCRIPTION
Jira tickets:
- https://codedotorg.atlassian.net/browse/P20-522
- https://codedotorg.atlassian.net/browse/CT-175

Platform discovered a translation bug due to an inconsistency where function definition blocks are assigned an ID, whereas function call blocks are not. My understanding is that when a function is defined in a translated language, the corresponding function call block cannot associate with the definition block due to the ID inconsistency, causing the program to crash or freeze.

The ID is added to function definition blocks when the modal function editor is enabled but not to the corresponding function call blocks. The ID addition is necessary for shared behaviors but is unintentionally applying to function blocks as well.

@mike and @molly-moen identified two potential solutions:
1. Translate function ids
2. Ignore function ids when we are generating code (always use the name)

For now, we decided to not use IDs for functions, because translating them adds extra complexity for a case we don’t really want to support. 